### PR TITLE
Add db_triggers input to deployment workflows

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -64,6 +64,10 @@ on:
         description: 'Deployment URL; used for environments'
         required: true
         type: string
+      db_triggers:
+        description: Paths used to trigger a database deployment; e.g. ('charts/crunchy/')
+        required: false
+        type: string
 
     outputs:
       tag:
@@ -96,7 +100,7 @@ jobs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
       triggered: ${{ steps.deploy.outputs.triggered }}
     steps:
-      - uses: bcgov/action-crunchy@ac46670c974c2238fffb635eee7bbd27735c25bc # v1.2.1
+      - uses: bcgov/action-crunchy@v1.2.2
         name: Deploy Crunchy
         id: deploy_crunchy
         with:
@@ -104,7 +108,7 @@ jobs:
           oc_token: ${{ secrets.OC_TOKEN }}
           environment: ${{ inputs.environment }}
           values_file: charts/crunchy/values.yml
-          triggers: ${{ inputs.triggers }}
+          triggers: ${{ inputs.db_triggers }}
 
       # Variables
       - if: inputs.tag  == ''

--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -37,6 +37,7 @@ jobs:
       db_user: app-${{ github.event.number }}
       params: --set global.secrets.persist=false
       triggers: ('backend/' 'frontend/' 'migrations/' 'charts/' 'github/')
+      db_triggers: ('charts/crunchy/')
       deployment_url: https://${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}-frontend.apps.silver.devops.gov.bc.ca
 
   update_secrets:


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

# Description

Introduces a new 'db_triggers' input to .deployer.yml and pr-open.yml for specifying database deployment trigger paths. Updates the bcgov/action-crunchy action to v1.2.2 and adjusts the workflow to use the new input.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
