### PR TITLE
fix(ui): Hide Tenants nav button when there are no tenants yet

### DIFF
--- a/frontend/src/components/layout/AppNavigation.vue
+++ b/frontend/src/components/layout/AppNavigation.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { useAuthStore } from '@/stores'
+import { useAuthStore, useTenantStore } from '@/stores'
 
 import { currentUserIsOperationsAdmin } from '@/utils/permissions'
+import { storeToRefs } from 'pinia'
 
 // --- Store and Composable Setup ----------------------------------------------
 
 const route = useRoute()
 const authStore = useAuthStore()
+const tenantStore = useTenantStore()
+
+//Refs
+const { tenants } = storeToRefs(tenantStore)
 
 // --- Computed Values ---------------------------------------------------------
 
@@ -22,7 +27,7 @@ const loggedIn = computed(() => authStore.isAuthenticated)
   <v-toolbar class="px-12" color="surface-light-gray" elevation="0" flat>
     <div class="d-flex align-center" style="gap: 8px">
       <v-btn
-        v-if="loggedIn"
+        v-if="loggedIn && tenants.length > 0"
         :active="isRouteTenant"
         exact-active-class=""
         to="/tenants"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description

Hides the tenant button from the nav when there are no tenants in the db

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
