### PR TITLE
fix(ui): auto select first tabs

### DIFF
--- a/frontend/src/components/route/GroupManagementContainer.vue
+++ b/frontend/src/components/route/GroupManagementContainer.vue
@@ -148,22 +148,16 @@ onMounted(async () => {
 
       <v-card class="mt-6" elevation="0">
         <v-tabs v-model="tab" :disabled="isEditing" :mandatory="false">
-          <!-- The v-tabs component insists on always having an active tab. Use
-           an invisible Tab 0 to make v-tabs happy. -->
-          <v-tab :value="0" class="pa-0 ma-0" style="min-width: 0px" />
+          <v-tab :value="0">Group Members</v-tab>
           <v-tab :value="1">Service Roles</v-tab>
-          <v-tab :value="2">Group Members</v-tab>
         </v-tabs>
 
         <v-window v-model="tab">
-          <v-window-item :value="0" />
-
+          <v-window-item :value="0">
+            <UserManagementContainer :group="group!" :tenant="tenant!" />
+          </v-window-item>
           <v-window-item :value="1">
             <GroupRoleContainer :group="group!" :tenant="tenant!" />
-          </v-window-item>
-
-          <v-window-item :value="2">
-            <UserManagementContainer :group="group!" :tenant="tenant!" />
           </v-window-item>
         </v-window>
       </v-card>

--- a/frontend/src/components/route/SettingsContainer.vue
+++ b/frontend/src/components/route/SettingsContainer.vue
@@ -15,21 +15,16 @@ const tab = ref<number>(0)
     <AdministratorContainer>
       <v-card elevation="0">
         <v-tabs v-model="tab" :mandatory="false">
-          <!-- The v-tabs component insists on always having an active tab. Use
-           an invisible Tab 0 to make v-tabs happy. -->
-          <v-tab :value="0" class="pa-0 ma-0" style="min-width: 0px" />
-          <v-tab :value="1">Tenant Requests</v-tab>
-          <v-tab :value="2">Shared Services</v-tab>
+          <v-tab :value="0">Tenant Requests</v-tab>
+          <v-tab :value="1">Shared Services</v-tab>
         </v-tabs>
 
         <v-window v-model="tab">
-          <v-window-item :value="0" />
-
-          <v-window-item :value="1">
+          <v-window-item :value="0">
             <TenantRequestContainer />
           </v-window-item>
 
-          <v-window-item :value="2">
+          <v-window-item :value="1">
             <v-container fluid>
               <v-row>
                 <v-col cols="12">

--- a/frontend/src/components/route/TenantManagementContainer.vue
+++ b/frontend/src/components/route/TenantManagementContainer.vue
@@ -112,21 +112,17 @@ onMounted(async () => {
 
       <v-card class="mt-6" elevation="0">
         <v-tabs v-model="tab" :disabled="isEditing" :mandatory="false">
-          <!-- The v-tabs component insists on always having an active tab. Use
-           an invisible Tab 0 to make v-tabs happy. -->
-          <v-tab :value="0" class="pa-0 ma-0" style="min-width: 0px" />
-          <v-tab :value="1">User Management</v-tab>
-          <v-tab :value="2">Available Services</v-tab>
+          <v-tab :value="0">User Management</v-tab>
+          <v-tab :value="1">Available Services</v-tab>
         </v-tabs>
 
         <v-window v-model="tab">
-          <v-window-item :value="0" />
 
-          <v-window-item :value="1">
+          <v-window-item :value="0">
             <UserManagementContainer :tenant="tenant!" />
           </v-window-item>
 
-          <v-window-item :value="2">
+          <v-window-item :value="1">
             <ServiceManagementContainer :tenant="tenant!" />
           </v-window-item>
         </v-window>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
When you navigate to tenant/group/settings the app lands on a blank page, we should show the first tab, creates a more logical flow with less clicks

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
