### PR TITLE
fix(ui): hide role editing button

### DIFF
--- a/frontend/src/components/tenant/TenantUserManagement.vue
+++ b/frontend/src/components/tenant/TenantUserManagement.vue
@@ -197,6 +197,9 @@ function showInfo(message: string) {
 }
 
 function showRoleDialog(user: User, index: number) {
+  if (!isUserAdmin.value) {
+    return
+  }
   modifyingUserIndex.value = index
   roleDialogVisible.value = true
 }
@@ -273,6 +276,7 @@ function handleCloseRoleDialog(open: boolean) {
           <template #[`item.roles`]="{ item, index }">
             <div class="d-flex flex-wrap" style="gap: 8px; margin-block: 4px">
               <v-btn
+                v-if="isUserAdmin"
                 class="default-radius"
                 icon="mdi-plus"
                 size="x-small"
@@ -398,6 +402,7 @@ function handleCloseRoleDialog(open: boolean) {
 
     <RoleDialog
       v-model="roleDialogVisible"
+      v-if="isUserAdmin"
       :tenant="tenant"
       :user-index="modifyingUserIndex"
       @update:open-dialog="handleCloseRoleDialog"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
If the user doesn't have the permissions to edit user roles they were being shown the button to do so, this allowed them to initiate a workflow they could never complete, don't allow them to start this flow

Please provide a summary of the change and the issue fixed. Please include relevant context. List dependency changes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
