### PR TITLE
fix(ui): set authenticated false if network error happens while fetching tenants

### DIFF
--- a/frontend/src/components/route/TenantListContainer.vue
+++ b/frontend/src/components/route/TenantListContainer.vue
@@ -79,7 +79,7 @@ const handleTenantSubmit = async (
 onMounted(async () => {
   try {
     await tenantStore.fetchTenants(authStore.authenticatedUser.id)
-  } catch(e: Error) {
+  } catch(e: any) {
     // This happens when the user has sat on a screen idle for a while and then tries to do something (but session is dead)
     if (e && e.code && e.code === "ERR_NETWORK") {
       console.error("Network error while fetching tenants:", e)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

# Description
If the tenant fetch returns a network error it will set authorized to false and not display the error banner (the user isn't logged in and that should have already been handled appropriately

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have already been accepted and merged


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
