### PR TITLE
fix: CCP-4498 header responsivity

### DIFF
--- a/frontend/src/components/group/GroupHeader.vue
+++ b/frontend/src/components/group/GroupHeader.vue
@@ -78,7 +78,7 @@ const groupMembersCount = computed(() => props.group.groupUsers.length)
 
     <v-divider class="my-6" />
 
-    <v-row class="align-center" style="column-gap: 8rem">
+    <v-row class="align-center">
       <v-col cols="12" md="3">
         <StatBlock
           :icon="mdiCalendarMonthOutline"
@@ -86,7 +86,7 @@ const groupMembersCount = computed(() => props.group.groupUsers.length)
           label="Date Created"
         />
       </v-col>
-      <v-col cols="12" md="3">
+      <v-col cols="12" md="9">
         <StatBlock
           :icon="mdiAccountCircleOutline"
           :value="group.createdBy"
@@ -95,7 +95,7 @@ const groupMembersCount = computed(() => props.group.groupUsers.length)
       </v-col>
     </v-row>
 
-    <v-row class="align-center" style="column-gap: 8rem">
+    <v-row class="align-center">
       <v-col cols="12" md="3">
         <StatBlock
           :icon="mdiAccountMultipleOutline"

--- a/frontend/src/components/tenant/TenantHeader.vue
+++ b/frontend/src/components/tenant/TenantHeader.vue
@@ -76,7 +76,7 @@ const tenantUsersCount = computed(() => props.tenant.users.length)
 
     <v-divider class="my-6" />
 
-    <v-row class="align-center" style="column-gap: 8rem">
+    <v-row class="align-center">
       <v-col cols="12" md="3">
         <StatBlock
           :icon="mdiCalendarMonthOutline"
@@ -84,7 +84,7 @@ const tenantUsersCount = computed(() => props.tenant.users.length)
           label="Date Created"
         />
       </v-col>
-      <v-col cols="12" md="3">
+      <v-col cols="12" md="9">
         <StatBlock
           :icon="mdiAccountCircleOutline"
           :value="tenant.createdBy"
@@ -93,7 +93,7 @@ const tenantUsersCount = computed(() => props.tenant.users.length)
       </v-col>
     </v-row>
 
-    <v-row class="align-center" style="column-gap: 8rem">
+    <v-row class="align-center">
       <v-col cols="12" md="3">
         <StatBlock
           :icon="mdiAccountMultipleOutline"


### PR DESCRIPTION
<!--
Give a general description of the changes in the Title above

Title format: <type>(<scope>): CCP-<jira id> <short description>
For example:  fix(ui): CCP-1234 make login button blue

Conventional Commit types: build, chore, ci, docs, feat, fix, perf, refactor,
  revert, style, test
-->

# Description

<!--
Give a detailed summary of the change.

Tip: the Jira ticket description, including "Acceptance Criteria", can be
written so that it can be pasted into this description.
-->

A last-minute change to the tenant and group detail components was to switch the created by username to the display name. The responsivity of the `StatBlock` component was clean before this change, but now the name is breaking across lines and isn’t behaving well on screen width adjustments. As this may require significant changes to the detail component layout, this item was left as technical debt to be resolved later.

### Acceptance Criteria
- Detail components have good responsivity when faced with long user display names
- May involve changing the “two stats per line” design

## Type of change

`fix`: a bug fix for the product
<!-- Uncomment the one type that applies - it will be also used in the title.
`build`: changes to the build system or dependencies
`chore`: miscellaneous changes that don't fit another type
`ci`: changes to CI/CD configuration and scripts
`docs`: documentation only changes
`feat`: a new feature for the product
`perf`: a code change that improves performance
`refactor`: a code change that neither fixes a bug nor adds a feature
`revert`: reverts a previous commit
`style`: changes that do not affect the meaning of the code
`test`: adding missing tests or correcting existing tests
-->

## Checklist

<!--
Check each item with an `x` to confirm that the step is complete. This list is
meant to be a helpful reminder of what is needed for a complete pull request.
-->

- [x] I have performed a thorough self-review of the changes in this PR
- [x] The changes are self-explanatory or have comments where needed
- [x] I have checked that documentation is still accurate after these changes
- [x] My changes are covered by the existing tests or tests have been added

## Further comments

> _Note: the fix was to adjust the container that uses the StatBlock components._

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://cstar-538.apps.gold.devops.gov.bc.ca)
- [Backend](https://cstar-538.apps.gold.devops.gov.bc.ca/api/v1)
- [OpenAPI](https://cstar-538.apps.gold.devops.gov.bc.ca/api/v1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/merge.yml)