### PR TITLE
test(api): CCP-4714 update Bruno tests for required identity provider type (recently made mandatory)

### DIFF
--- a/tests/integration/collection/_fixtures/create tenant with service user.yml
+++ b/tests/integration/collection/_fixtures/create tenant with service user.yml
@@ -19,6 +19,7 @@ http:
           "displayName": "Saramago, Salman CITZ:EX",
           "email": "Salman.Saramago@gov.bc.ca",
           "firstName": "Salman",
+          "idpType": "idir",
           "lastName": "Saramago",
           "ssoUserId": "23BCA2E3B9C6408595322A138F9EF5CA",
           "userName": "SSARAMAG"

--- a/tests/integration/collection/_fixtures/create tenant.yml
+++ b/tests/integration/collection/_fixtures/create tenant.yml
@@ -18,6 +18,7 @@ http:
           "displayName": "Orwell, Odysseus CITZ:EX",
           "email": "Odysseus.Orwell@gov.bc.ca",
           "firstName": "Odysseus",
+          "idpType": "idir",
           "lastName": "Orwell",
           "ssoUserId": "820D17EA8C90438A9A74925B442CE775",
           "userName": "OORWELL"

--- a/tests/integration/collection/_setup/setup hack.yml
+++ b/tests/integration/collection/_setup/setup hack.yml
@@ -16,6 +16,7 @@ http:
           "displayName": "Orwell, Osysseus CITZ:EX",
           "email": "Odysseus.Orwell@gov.bc.ca",
           "firstName": "Odysseus",
+          "idpType": "idir",
           "lastName": "Orwell",
           "ssoUserId": "820D17EA8C90438A9A74925B442CE775",
           "userName": "OORWELL"

--- a/tests/integration/collection/create tenant/create tenant.yml
+++ b/tests/integration/collection/create tenant/create tenant.yml
@@ -16,6 +16,7 @@ http:
           "displayName": "Orwell, Odysseus CITZ:EX",
           "email": "Odysseus.Orwell@gov.bc.ca",
           "firstName": "Odysseus",
+          "idpType": "idir",
           "lastName": "Orwell",
           "ssoUserId": "820D17EA8C90438A9A74925B442CE775",
           "userName": "OORWELL"

--- a/tests/integration/collection/tenant add user/add service user.yml
+++ b/tests/integration/collection/tenant add user/add service user.yml
@@ -17,6 +17,7 @@ http:
           "displayName": "Saramago, Salman CITZ:EX",
           "email": "Salman.Saramago@gov.bc.ca",
           "firstName": "Salman",
+          "idpType": "idir",
           "lastName": "Saramago",
           "ssoUserId": "23BCA2E3B9C6408595322A138F9EF5CA",
           "userName": "SSARAMAG"


### PR DESCRIPTION
Updates the existing Bruno integration-test request payloads to match the current backend validations.

The `idpType` field became required when creating tenants and adding tenant users, but the Bruno tests were not updatedand were failing as a result. So tenant creation etc. returned 400s and caused bruno integration tests to fail.

change adds `"idpType": "idir"` to five failing existing requests in the bruno tests. No other updates 

## Checklist

<!--
Check each item with an `x` to confirm that the step is complete. This list is
meant to be a helpful reminder of what is needed for a complete pull request.
-->

- [x] I have performed a thorough self-review of the changes in this PR
- [x] The changes are self-explanatory or have comments where needed
- [x] I have checked that documentation is still accurate after these changes
- [x] My changes are covered by the existing tests or tests have been added

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://cstar-587.apps.gold.devops.gov.bc.ca)
- [Backend](https://cstar-587.apps.gold.devops.gov.bc.ca/api/v1)
- [OpenAPI](https://cstar-587.apps.gold.devops.gov.bc.ca/api/v1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/merge.yml)