### PR TITLE
fix: CCP-4990 prevent flashy pages

### DIFF
--- a/frontend/src/__tests__/README.md
+++ b/frontend/src/__tests__/README.md
@@ -5,7 +5,40 @@ for the Vue components, and standard unit tests for everything else.
 
 ## Component Testing
 
-Documentation to be completed
+Vue components are tested using the framework that best matches the type of
+component being tested.
+
+### Presentational Components
+
+Presentational components are tested using Vue Testing Library. These components
+primarily render UI and emit events, with little or no business logic.
+
+Tests should interact with the component in the same way a user would:
+
+- Find elements by their accessible role or text
+- Simulate user interactions such as clicking buttons or entering text
+- Assert on visible behaviour rather than implementation details
+
+Tests should not inspect component internals such as reactive state, computed
+properties, or child component props.
+
+### Container Components
+
+Container components are tested using Vue Test Utils. These components
+coordinate stores, routing, and communication between child components, and
+typically contain little or no rendered UI of their own.
+
+Tests focus on verifying that the container correctly coordinates its
+dependencies, for example:
+
+- Child component events are handled correctly
+- The appropriate store or service methods are called
+- Navigation occurs when expected
+- Correct props are passed to child components
+
+Inspecting child component props and emitting events directly from component
+stubs is acceptable for container tests because these interactions are the
+behaviour under test.
 
 ## Non-Component Testing
 
@@ -13,18 +46,17 @@ For code that is not a Vue component, the unit under test is a function. Complex
 dependencies like the ORM or network are mocked, and the units are tested as
 black boxes. Subtleties are described in the sections below.
 
-###
+### Factories
 
 Factories in `__factories__` generate objects either in the shape of API
 data or for the models themselves.
 
-1. Factories should always be used when creating testing data
-1. The default data from the factory should never be used for assertions. For
-   example, if using `expect(tenant.name).toBe(...)` then the value must not be
-   the factory default (as the factory might change). The value must be
-   specified using the factory override (`makeTenant({ name: 'n'})`), and then
-   asserted (`expect(tenant.name).toBe('n')`), which makes the test code more
-   readable.
+- Factories should always be used when creating testing data
+- The default data from the factory should never be used for assertions. For
+  example, if using `expect(tenant.name).toBe(...)` then the value must not be
+  the factory default (as the factory might change). The value must be specified
+  using the factory override (`makeTenant({ name: 'n'})`), and then asserted
+  (`expect(tenant.name).toBe('n')`), which makes the test code more readable
 
 ### Services
 

--- a/frontend/src/__tests__/components/route/GroupHeaderContainer.test.ts
+++ b/frontend/src/__tests__/components/route/GroupHeaderContainer.test.ts
@@ -1,0 +1,158 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  makeGroup,
+  makeGroupService,
+  makeGroupServiceRole,
+  makeTenant,
+} from '@/__tests__/__factories__'
+
+import GroupHeaderContainer from '@/components/route/GroupHeaderContainer.vue'
+import { useNotification } from '@/composables/useNotification'
+import { toGroupId } from '@/models/group.model'
+import { toGroupServiceRoleId } from '@/models/groupservicerole.model'
+import { toTenantId } from '@/models/tenant.model'
+import { useGroupStore } from '@/stores/useGroupStore'
+import { useTenantStore } from '@/stores/useTenantStore'
+import { toGroupServiceId } from '@/models/groupservice.model'
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: vi.fn(),
+}))
+
+const mountComponent = () =>
+  mount(GroupHeaderContainer, {
+    global: {
+      stubs: {
+        GroupHeader: true,
+        LoadingWrapper: { template: '<div><slot /></div>' },
+        LoginContainer: { template: '<div><slot /></div>' },
+        RouterView: { template: '<div data-testid="router-view" />' },
+      },
+    },
+    props: {
+      groupId: toGroupId('groupId1'),
+      tenantId: toTenantId('tenantId1'),
+    },
+  })
+
+describe('GroupHeaderContainer', () => {
+  let groupStore: ReturnType<typeof useGroupStore>
+  let notificationMock: ReturnType<typeof useNotification>
+  let tenantStore: ReturnType<typeof useTenantStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+
+    groupStore = useGroupStore()
+    tenantStore = useTenantStore()
+
+    groupStore.fetchGroup = vi.fn().mockResolvedValue(undefined)
+    groupStore.fetchGroupServices = vi.fn().mockResolvedValue(undefined)
+
+    notificationMock = {
+      items: [],
+
+      info: vi.fn(),
+      error: vi.fn(),
+      success: vi.fn(),
+      remove: vi.fn(),
+      warning: vi.fn(),
+    }
+
+    vi.mocked(useNotification).mockReturnValue(notificationMock)
+  })
+
+  it('fetches the group and group services on mount', async () => {
+    mountComponent()
+
+    expect(groupStore.fetchGroup).toHaveBeenCalledWith('tenantId1', 'groupId1')
+    expect(groupStore.fetchGroupServices).toHaveBeenCalledWith(
+      'tenantId1',
+      'groupId1',
+    )
+  })
+
+  it('shows an error when loading the group fails', async () => {
+    groupStore.fetchGroup = vi.fn().mockRejectedValue(new Error())
+
+    mountComponent()
+    await flushPromises()
+
+    expect(notificationMock.error).toHaveBeenCalledWith('Failed to load group')
+  })
+
+  it('shows an error when loading group services fails', async () => {
+    groupStore.fetchGroupServices = vi.fn().mockRejectedValue(new Error())
+
+    mountComponent()
+    await flushPromises()
+
+    expect(notificationMock.error).toHaveBeenCalledWith(
+      'Failed to load group servicess',
+    )
+  })
+
+  it('passes computed props to GroupHeader', async () => {
+    groupStore.groups = [makeGroup({ id: toGroupId('groupId1') })]
+    groupStore.groupServices = [
+      makeGroupService({
+        id: toGroupServiceId('groupService1'),
+        roles: [
+          makeGroupServiceRole({
+            id: toGroupServiceRoleId('role1'),
+            isEnabled: false,
+            name: 'Role 1',
+          }),
+        ],
+      }),
+      makeGroupService({
+        id: toGroupServiceId('groupService2'),
+        roles: [
+          makeGroupServiceRole({
+            id: toGroupServiceRoleId('role2'),
+            isEnabled: true,
+            name: 'Role 2',
+          }),
+          makeGroupServiceRole({
+            id: toGroupServiceRoleId('role3'),
+            isEnabled: false,
+            name: 'Role 3',
+          }),
+          makeGroupServiceRole({
+            id: toGroupServiceRoleId('role4'),
+            isEnabled: true,
+            name: 'Role 4',
+          }),
+        ],
+      }),
+      makeGroupService({
+        id: toGroupServiceId('groupService3'),
+        roles: [
+          makeGroupServiceRole({
+            id: toGroupServiceRoleId('role5'),
+            isEnabled: true,
+            name: 'Role 5',
+          }),
+        ],
+      }),
+    ]
+    tenantStore.tenants = [makeTenant({ id: toTenantId('tenantId1') })]
+
+    const wrapper = mountComponent()
+
+    const header = wrapper.getComponent({ name: 'GroupHeader' })
+    expect(header.props('group')).toEqual(groupStore.groups[0])
+    expect(header.props('tenant')).toEqual(tenantStore.tenants[0])
+    expect(header.props('enabledRolesCount')).toBe(3)
+    expect(header.props('enabledServiceCount')).toBe(2)
+  })
+
+  it('renders the router view', async () => {
+    const wrapper = mountComponent()
+
+    expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/components/route/GroupListContainer.test.ts
+++ b/frontend/src/__tests__/components/route/GroupListContainer.test.ts
@@ -1,206 +1,392 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
 
 import { makeGroup, makeTenant, makeUser } from '@/__tests__/__factories__'
+import { createMockAuthStore } from '@/__tests__/__helpers__/useAuthStore.mock'
 
 import GroupListContainer from '@/components/route/GroupListContainer.vue'
 import { DomainError } from '@/errors/domain/DomainError'
+import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
 import { ServerError } from '@/errors/domain/ServerError'
-import { Group, toGroupId } from '@/models/group.model'
+import { toGroupId } from '@/models/group.model'
 import { toTenantId } from '@/models/tenant.model'
-import { User } from '@/models/user.model'
-import { useAuthStore } from '@/stores/useAuthStore'
+import { toUserId } from '@/models/user.model'
 import { useGroupStore } from '@/stores/useGroupStore'
 import { useTenantStore } from '@/stores/useTenantStore'
 import { currentUserHasRole } from '@/utils/permissions'
 
-vi.mock('@/services/config.service', () => ({
-  config: { api: { baseUrl: 'http://localhost/api' }, oidc: {} },
-}))
-
-const mockNotify = { success: vi.fn(), error: vi.fn() }
-vi.mock('@/composables/useNotification', () => ({
-  useNotification: () => mockNotify,
-}))
-
+const mockError = vi.fn()
 const mockPush = vi.fn()
+const mockSuccess = vi.fn()
+
 vi.mock('vue-router', () => ({
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: () => ({
+    error: mockError,
+    success: mockSuccess,
+  }),
+}))
+
+let currentAuthStore = createMockAuthStore()
+
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: () => currentAuthStore,
 }))
 
 vi.mock('@/utils/permissions', () => ({
   currentUserHasRole: vi.fn(),
 }))
 
-vi.mock('@/stores/useAuthStore', () => ({ useAuthStore: vi.fn() }))
-vi.mock('@/stores/useGroupStore', () => ({ useGroupStore: vi.fn() }))
-vi.mock('@/stores/useTenantStore', () => ({ useTenantStore: vi.fn() }))
-
-type AuthStoreMock = Partial<ReturnType<typeof useAuthStore>>
-type GroupStoreMock = Partial<ReturnType<typeof useGroupStore>>
-type TenantStoreMock = Partial<ReturnType<typeof useTenantStore>>
-
-const mountComponent = (tenantId = 't1') => {
-  return mount(GroupListContainer, {
-    props: { tenantId: toTenantId(tenantId) },
+const mountComponent = () =>
+  mount(GroupListContainer, {
+    props: {
+      tenantId: toTenantId('tenantId1'),
+    },
     global: {
       stubs: {
+        ButtonPrimary: {
+          emits: ['click'],
+          name: 'ButtonPrimary',
+          template: `
+            <button @click="$emit('click')">
+              create
+            </button>
+          `,
+        },
         GroupCreateDialog: {
+          emits: ['clear-duplicate-error', 'submit', 'update:modelValue'],
           name: 'GroupCreateDialog',
-          template: '<div id="dialog-stub" />',
           props: ['isDuplicateName', 'modelValue'],
+          template: '<div />',
         },
         GroupList: {
+          emits: ['select'],
           name: 'GroupList',
-          template: '<div id="list-stub" />',
-          props: ['groups', 'isAdmin'],
+          props: ['groups'],
+          template: '<div />',
         },
         LoginContainer: {
           template: '<div><slot /></div>',
         },
-        ButtonPrimary: {
-          template:
-            '<button id="create-btn" @click="$emit(\'click\')"><slot /></button>',
+        'v-col': {
+          template: '<div><slot /></div>',
         },
         'v-container': {
-          template: '<div class="v-container-stub"><slot /></div>',
+          template: '<div><slot /></div>',
         },
-        'v-row': { template: '<div><slot /></div>' },
-        'v-col': { template: '<div><slot /></div>' },
+        'v-row': {
+          template: '<div><slot /></div>',
+        },
       },
     },
   })
-}
 
-describe('GroupListContainer.vue', () => {
-  let mockAuth: AuthStoreMock
-  let mockGroup: GroupStoreMock
+describe('GroupListContainer', () => {
+  let groupStore: ReturnType<typeof useGroupStore>
+  let tenantStore: ReturnType<typeof useTenantStore>
 
   beforeEach(() => {
-    vi.clearAllMocks()
     setActivePinia(createPinia())
-    mockAuth = { authenticatedUser: null as unknown as User }
-    mockGroup = {
-      addGroup: vi.fn(),
-      addGroupUser: vi.fn(),
-      loading: false,
-      groups: [] as Group[],
-    }
-    const mockTenant: TenantStoreMock = {
-      getTenant: vi.fn().mockReturnValue(makeTenant({ id: toTenantId('t1') })),
-    }
-    vi.mocked(useAuthStore).mockReturnValue(
-      mockAuth as ReturnType<typeof useAuthStore>,
-    )
-    vi.mocked(useGroupStore).mockReturnValue(
-      mockGroup as ReturnType<typeof useGroupStore>,
-    )
-    vi.mocked(useTenantStore).mockReturnValue(
-      mockTenant as ReturnType<typeof useTenantStore>,
-    )
+    vi.clearAllMocks()
+
+    currentAuthStore = createMockAuthStore({
+      user: makeUser(),
+    })
+
+    groupStore = useGroupStore()
+    groupStore.groups = []
+
+    tenantStore = useTenantStore()
+    tenantStore.tenants = [makeTenant({ id: toTenantId('tenantId1') })]
+
+    vi.mocked(currentUserHasRole).mockReturnValue(false)
   })
 
-  describe('Template and Lifecycle', () => {
+  it('throws an error when tenant is not found', () => {
+    tenantStore.getTenant = vi.fn().mockReturnValue(undefined)
+
+    expect(() => mountComponent()).toThrow('Tenant tenantId1 not found')
+  })
+
+  describe('create button', () => {
+    it('shows when user is admin and no groups', () => {
+      groupStore.groups = []
+      vi.mocked(currentUserHasRole).mockReturnValue(true)
+
+      const wrapper = mountComponent()
+
+      expect(wrapper.findComponent({ name: 'ButtonPrimary' }).exists()).toBe(
+        true,
+      )
+    })
+
+    it('shows when user is admin and has groups', () => {
+      groupStore.groups = [makeGroup()]
+      vi.mocked(currentUserHasRole).mockReturnValue(true)
+
+      const wrapper = mountComponent()
+
+      expect(wrapper.findComponent({ name: 'ButtonPrimary' }).exists()).toBe(
+        true,
+      )
+    })
+
+    it('hides when user is not admin and no groups', () => {
+      groupStore.groups = []
+      vi.mocked(currentUserHasRole).mockReturnValue(false)
+
+      const wrapper = mountComponent()
+
+      expect(wrapper.findComponent({ name: 'ButtonPrimary' }).exists()).toBe(
+        false,
+      )
+    })
+
+    it('hides when user is not admin and has groups', () => {
+      groupStore.groups = [makeGroup()]
+      vi.mocked(currentUserHasRole).mockReturnValue(false)
+
+      const wrapper = mountComponent()
+
+      expect(wrapper.findComponent({ name: 'ButtonPrimary' }).exists()).toBe(
+        false,
+      )
+    })
+  })
+
+  describe('template', () => {
     it('renders empty state when no groups exist', () => {
-      mockGroup.groups = []
       const wrapper = mountComponent()
-      expect(wrapper.find('.v-container-stub').exists()).toBe(true)
+
+      expect(wrapper.text()).toContain('No groups yet')
     })
 
-    it('handles clear-duplicate-error event', async () => {
-      const wrapper = mountComponent()
-      const dialog = wrapper.getComponent({ name: 'GroupCreateDialog' })
-
-      await dialog.vm.$emit('clear-duplicate-error')
-      expect(dialog.props('isDuplicateName')).toBe(false)
-    })
-  })
-
-  describe('handleGroupCreate Logic', () => {
-    it('skips user addition if addUser is false', async () => {
-      const addMock = vi.mocked(mockGroup.addGroup)
-      if (addMock) {
-        addMock.mockResolvedValue(makeGroup())
-      }
-      const addUserSpy = vi.spyOn(mockGroup, 'addGroupUser')
+    it('renders GroupList when groups exist', () => {
+      groupStore.groups = [makeGroup()]
 
       const wrapper = mountComponent()
-      const dialog = wrapper.getComponent({ name: 'GroupCreateDialog' })
 
-      await dialog.vm.$emit('submit', { name: 'G' }, false)
-      await nextTick()
-
-      expect(addMock).toHaveBeenCalled()
-      expect(addUserSpy).not.toHaveBeenCalled()
-    })
-
-    it('handles successful creation and user addition', async () => {
-      const user = makeUser()
-      Object.assign(mockAuth, { authenticatedUser: user })
-      vi.mocked(currentUserHasRole).mockReturnValue(true)
-
-      const addMock = vi.mocked(mockGroup.addGroup)
-      if (addMock) {
-        addMock.mockResolvedValue(makeGroup())
-      }
-      const addUserMock = vi.mocked(mockGroup.addGroupUser)
-      if (addUserMock) {
-        addUserMock.mockResolvedValue(undefined)
-      }
-
-      const wrapper = mountComponent()
-      const dialog = wrapper.getComponent({ name: 'GroupCreateDialog' })
-
-      await dialog.vm.$emit('submit', { name: 'New G' }, true)
-      await nextTick()
-      await nextTick()
-
-      expect(mockNotify.success).toHaveBeenCalledWith(
-        'User added to Group Successfully',
-      )
-    })
-
-    it('covers error branches during creation and addition', async () => {
-      vi.mocked(currentUserHasRole).mockReturnValue(true)
-      const wrapper = mountComponent()
-      const dialog = wrapper.getComponent({ name: 'GroupCreateDialog' })
-      const addMock = vi.mocked(mockGroup.addGroup)
-
-      const srvError = new ServerError('Tech')
-      Object.defineProperty(srvError, 'userMessage', { value: null })
-      if (addMock) {
-        addMock.mockRejectedValueOnce(srvError)
-      }
-      await dialog.vm.$emit('submit', { name: 'G' }, false)
-      await nextTick()
-      expect(mockNotify.error).toHaveBeenLastCalledWith(
-        'Failed to create the new group',
-      )
-
-      const user = makeUser()
-      Object.assign(mockAuth, { authenticatedUser: user })
-      if (addMock) {
-        addMock.mockResolvedValue(makeGroup())
-      }
-      const addUserMock = vi.mocked(mockGroup.addGroupUser)
-      if (addUserMock) {
-        addUserMock.mockRejectedValueOnce(new DomainError('E', 'Add Fail'))
-      }
-
-      await dialog.vm.$emit('submit', { name: 'G' }, true)
-      await nextTick()
-      await nextTick()
-      expect(mockNotify.error).toHaveBeenLastCalledWith('Add Fail')
+      expect(wrapper.findComponent({ name: 'GroupList' }).exists()).toBe(true)
     })
   })
 
-  it('navigates to group members on selection', async () => {
-    mockGroup.groups = [makeGroup({ id: toGroupId('g1') })]
-    const wrapper = mountComponent()
-    const list = wrapper.getComponent({ name: 'GroupList' })
-    await list.vm.$emit('select', 'g1')
-    expect(mockPush).toHaveBeenCalledWith('/tenants/t1/groups/g1/members')
+  describe('navigation', () => {
+    it('navigates to group members when group selected', async () => {
+      groupStore.groups = [makeGroup({ id: toGroupId('groupId1') })]
+
+      const wrapper = mountComponent()
+      await wrapper
+        .findComponent({ name: 'GroupList' })
+        .vm.$emit('select', 'groupId1')
+
+      expect(mockPush).toHaveBeenCalledWith(
+        '/tenants/tenantId1/groups/groupId1/members',
+      )
+    })
+  })
+
+  describe('dialog', () => {
+    it('opens create dialog when create button clicked', async () => {
+      vi.mocked(currentUserHasRole).mockReturnValue(true)
+
+      const wrapper = mountComponent()
+      await wrapper.findComponent({ name: 'ButtonPrimary' }).trigger('click')
+
+      expect(
+        wrapper
+          .findComponent({ name: 'GroupCreateDialog' })
+          .props('modelValue'),
+      ).toBe(true)
+    })
+
+    it('updates dialog visibility when dialog emits update:modelValue', async () => {
+      const wrapper = mountComponent()
+      const dialog = wrapper.findComponent({ name: 'GroupCreateDialog' })
+
+      expect(dialog.props('modelValue')).toBe(false)
+
+      await dialog.vm.$emit('update:modelValue', true)
+
+      expect(dialog.props('modelValue')).toBe(true)
+
+      await dialog.vm.$emit('update:modelValue', false)
+
+      expect(dialog.props('modelValue')).toBe(false)
+    })
+
+    it('clears duplicate error when requested', async () => {
+      const wrapper = mountComponent()
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('clear-duplicate-error')
+
+      expect(
+        wrapper
+          .findComponent({ name: 'GroupCreateDialog' })
+          .props('isDuplicateName'),
+      ).toBe(false)
+    })
+  })
+
+  describe('handleGroupCreate', () => {
+    it('creates group without adding user', async () => {
+      groupStore.addGroup = vi.fn().mockResolvedValue(makeGroup())
+      groupStore.addGroupUser = vi.fn()
+
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(groupStore.addGroup).toHaveBeenCalled()
+      expect(groupStore.addGroupUser).not.toHaveBeenCalled()
+      expect(mockSuccess).toHaveBeenCalledWith('Group Created Successfully')
+    })
+
+    it('shows group duplicate error', async () => {
+      groupStore.addGroup = vi
+        .fn()
+        .mockRejectedValue(new DuplicateEntityError())
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(
+        wrapper
+          .findComponent({ name: 'GroupCreateDialog' })
+          .props('isDuplicateName'),
+      ).toBe(true)
+    })
+
+    it('shows group domain error message', async () => {
+      groupStore.addGroup = vi
+        .fn()
+        .mockRejectedValue(new DomainError('message', 'userMessage'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('userMessage')
+    })
+
+    it('shows group generic when domain error without user message', async () => {
+      groupStore.addGroup = vi
+        .fn()
+        .mockRejectedValue(new DomainError('message'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('Failed to create the new group')
+    })
+
+    it('shows group server error message', async () => {
+      groupStore.addGroup = vi
+        .fn()
+        .mockRejectedValue(new ServerError('userMessage'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('userMessage')
+    })
+
+    it('shows group generic error when server error has no user message', async () => {
+      const error = new ServerError()
+      groupStore.addGroup = vi.fn().mockRejectedValue(error)
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('Failed to create the new group')
+    })
+
+    it('shows group generic error when group creation fails unexpectedly', async () => {
+      groupStore.addGroup = vi.fn().mockRejectedValue(new Error('error'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, false)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('Failed to create the new group')
+    })
+
+    it('adds user when requested', async () => {
+      const user = makeUser({ id: toUserId('userId1') })
+      currentAuthStore = createMockAuthStore({
+        user: user,
+      })
+      groupStore.addGroup = vi.fn().mockResolvedValue(makeGroup())
+      groupStore.addGroupUser = vi.fn().mockResolvedValue(undefined)
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, true)
+      await flushPromises()
+
+      expect(groupStore.addGroupUser).toHaveBeenCalledWith(
+        'tenantId1',
+        expect.anything(),
+        user,
+      )
+    })
+
+    it('shows user error when DomainError has user message', async () => {
+      groupStore.addGroup = vi.fn().mockResolvedValue(makeGroup())
+      groupStore.addGroupUser = vi
+        .fn()
+        .mockRejectedValue(new DomainError('message', 'userMessage'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, true)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('userMessage')
+    })
+
+    it('shows user generic error when DomainError has no user message', async () => {
+      groupStore.addGroup = vi.fn().mockResolvedValue(makeGroup())
+      groupStore.addGroupUser = vi
+        .fn()
+        .mockRejectedValue(new DomainError('message'))
+      const wrapper = mountComponent()
+
+      await wrapper
+        .findComponent({ name: 'GroupCreateDialog' })
+        .vm.$emit('submit', { description: 'description', name: 'name' }, true)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith(
+        'Failed to add the user to the new group',
+      )
+    })
   })
 })

--- a/frontend/src/__tests__/components/route/GroupMemberContainer.test.ts
+++ b/frontend/src/__tests__/components/route/GroupMemberContainer.test.ts
@@ -1,7 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/vue'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
 
 import {
   makeGroup,
@@ -15,8 +14,10 @@ import { useNotification } from '@/composables/useNotification'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
 import { toGroupId } from '@/models/group.model'
 import { toTenantId } from '@/models/tenant.model'
-import { toUserId, User } from '@/models/user.model'
+import { toUserId } from '@/models/user.model'
+import vuetify from '@/plugins/vuetify'
 import { useGroupStore } from '@/stores/useGroupStore'
+import { useTenantStore } from '@/stores/useTenantStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { IDIR_SEARCH_TYPE } from '@/utils/constants'
 
@@ -24,144 +25,110 @@ vi.mock('@/composables/useNotification', () => ({
   useNotification: vi.fn(),
 }))
 
-function makeGroupMemberManagementStub({
-  addUser = makeUser({ id: toUserId('u1') }),
-  duplicateUser = makeUser({
-    ssoUser: makeSsoUser({ displayName: 'displayName' }),
-  }),
-} = {}) {
-  return {
-    emits: ['add', 'delete', 'search', 'clear-search', 'cancel'],
-    name: 'GroupMemberManagement',
-    props: ['group', 'tenant', 'loadingSearch', 'searchResults'],
-    setup() {
-      return { addUser, duplicateUser, IDIR_SEARCH_TYPE }
-    },
-    template: `
-      <div>
-        <div data-testid="loading-search">{{ String(loadingSearch) }}</div>
-        <div data-testid="search-results-count">
-          {{ searchResults === null ? 'null' : searchResults.length }}
-        </div>
-        <button @click="$emit('add', addUser)">stub-add</button>
-        <button @click="$emit('add', duplicateUser)">stub-add-duplicate</button>
-        <button @click="$emit('delete', 'gu1')">stub-delete</button>
-        <button
-          @click="$emit('search', IDIR_SEARCH_TYPE.FIRST_NAME.value, 'firstName')"
-        >
-          stub-search-first-name
-        </button>
-        <button
-          @click="$emit('search', IDIR_SEARCH_TYPE.LAST_NAME.value, 'lastName')"
-        >
-          stub-search-last-name
-        </button>
-        <button
-          @click="$emit('search', IDIR_SEARCH_TYPE.EMAIL.value,
-          'firstName.lastName@gov.bc.ca')"
-        >
-          stub-search-email
-        </button>
-        <button @click="$emit('search', 'invalidSearch', 'invalidSearch')">
-          stub-invalid-search
-        </button>
-        <button @click="$emit('clear-search')">stub-clear-search</button>
-        <button @click="$emit('cancel')">stub-cancel</button>
-      </div>
-    `,
-  }
+const child = (wrapper: ReturnType<typeof mountComponent>) => {
+  return wrapper.getComponent({ name: 'GroupMemberManagement' })
 }
 
-function renderComponent(
-  groupId = toGroupId('g1'),
-  tenantId = toTenantId('t1'),
-  stubOptions: {
-    addUser?: User
-    duplicateUser?: User
-  } = {},
-) {
-  return render(GroupMemberContainer, {
+const mountComponent = (groupId = 'groupId1', tenantId = 'tenantId1') => {
+  return mount(GroupMemberContainer, {
     global: {
+      plugins: [vuetify],
       stubs: {
-        GroupMemberManagement: makeGroupMemberManagementStub(stubOptions),
+        GroupMemberManagement: true,
+        LoginContainer: { template: '<div><slot /></div>' },
       },
     },
-    props: { groupId, tenantId },
+    props: { groupId: toGroupId(groupId), tenantId: toTenantId(tenantId) },
   })
 }
 
 describe('GroupMemberContainer', () => {
   let groupStore: ReturnType<typeof useGroupStore>
-  let notificationMock: ReturnType<typeof useNotification>
+  let tenantStore: ReturnType<typeof useTenantStore>
   let userStore: ReturnType<typeof useUserStore>
+  let notificationMock: ReturnType<typeof useNotification>
 
   beforeEach(() => {
     setActivePinia(createPinia())
+
     groupStore = useGroupStore()
+    groupStore.groups = [makeGroup({ id: toGroupId('groupId1') })]
+
+    tenantStore = useTenantStore()
+    tenantStore.tenants = [makeTenant({ id: toTenantId('tenantId1') })]
+
+    userStore = useUserStore()
+
     notificationMock = {
+      items: [],
+
       error: vi.fn(),
       info: vi.fn(),
-      items: [],
       remove: vi.fn(),
       success: vi.fn(),
       warning: vi.fn(),
     }
     vi.mocked(useNotification).mockReturnValue(notificationMock)
-    userStore = useUserStore()
+  })
+
+  describe('group and tenant computed', () => {
+    it('passes the resolved group and tenant down as props', async () => {
+      const group = makeGroup({ id: toGroupId('groupId1') })
+      groupStore.groups = [group]
+      const tenant = makeTenant({ id: toTenantId('tenantId1') })
+      tenantStore.tenants = [tenant]
+
+      const wrapper = mountComponent()
+
+      expect(child(wrapper).props('group')).toEqual(group)
+      expect(child(wrapper).props('tenant')).toEqual(tenant)
+    })
   })
 
   describe('handleAddMember', () => {
     it('calls addGroupUser, clears searchResults, and shows success notification', async () => {
-      const addUser = makeUser({ id: toUserId('u1') })
-      const group = makeGroup({ id: toGroupId('g1') })
-      const tenant = makeTenant({ id: toTenantId('t1') })
+      const user = makeUser({ id: toUserId('userId1') })
       groupStore.addGroupUser = vi.fn().mockResolvedValue(undefined)
 
-      renderComponent(group.id, tenant.id)
-      await fireEvent.click(screen.getByRole('button', { name: 'stub-add' }))
+      const wrapper = mountComponent('groupId1', 'tenantId1')
+      await child(wrapper).vm.$emit('add', user)
+      await flushPromises()
 
       expect(groupStore.addGroupUser).toHaveBeenCalledWith(
-        tenant.id,
-        group.id,
-        addUser,
+        'tenantId1',
+        'groupId1',
+        user,
       )
       expect(notificationMock.success).toHaveBeenCalledWith(
         'New member successfully added to this group',
         'Member Added',
       )
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent(
-        'null',
-      )
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
 
-    it('shows duplicate error notification and clears results on DuplicateEntityError', async () => {
-      const duplicateUser = makeUser({
-        ssoUser: makeSsoUser({ displayName: 'displayName2' }),
+    it('shows duplicate error and clears searchResults on DuplicateEntityError', async () => {
+      const user = makeUser({
+        ssoUser: makeSsoUser({ displayName: 'displayName' }),
       })
-      groupStore.addGroupUser = vi
-        .fn()
-        .mockRejectedValue(new DuplicateEntityError())
+      const error = new DuplicateEntityError()
+      groupStore.addGroupUser = vi.fn().mockRejectedValue(error)
 
-      renderComponent(undefined, undefined, { duplicateUser })
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-add-duplicate' }),
-      )
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit('add', user)
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
-        expect.stringContaining('displayName2'),
+        expect.stringContaining('displayName'),
       )
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent(
-        'null',
-      )
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
 
-    it('shows generic error notification on unexpected error', async () => {
-      groupStore.addGroupUser = vi
-        .fn()
-        .mockRejectedValue(new Error('unexpected'))
+    it('shows generic error notification on unexpected addGroupUser error', async () => {
+      groupStore.addGroupUser = vi.fn().mockRejectedValue(new Error('message'))
 
-      renderComponent()
-      await fireEvent.click(screen.getByRole('button', { name: 'stub-add' }))
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit('add', makeUser())
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to add member to group',
@@ -171,40 +138,52 @@ describe('GroupMemberContainer', () => {
 
   describe('handleClearSearch', () => {
     it('sets searchResults to null', async () => {
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-clear-search' }),
-      )
+      userStore.searchIdirEmail = vi
+        .fn()
+        .mockResolvedValue([makeUser({ id: toUserId('userId1') })])
+      userStore.searchBCeIDEmail = vi
+        .fn()
+        .mockResolvedValue([makeUser({ id: toUserId('userId2') })])
 
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent(
-        'null',
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.EMAIL.value,
+        'email@example.com',
       )
+      await flushPromises()
+
+      await child(wrapper).vm.$emit('clear-search')
+
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
   })
 
   describe('handleDeleteMember', () => {
     it('calls removeGroupUser and shows success notification', async () => {
-      const group = makeGroup({ id: toGroupId('g1') })
-      const tenant = makeTenant({ id: toTenantId('t1') })
       groupStore.removeGroupUser = vi.fn().mockResolvedValue(undefined)
 
-      renderComponent(group.id, tenant.id)
+      const wrapper = mountComponent('groupId1', 'tenantId1')
+      await child(wrapper).vm.$emit('delete', 'groupUserId1')
+      await flushPromises()
 
-      await fireEvent.click(screen.getByRole('button', { name: 'stub-delete' }))
-
-      expect(groupStore.removeGroupUser).toHaveBeenCalledWith('t1', 'g1', 'gu1')
+      expect(groupStore.removeGroupUser).toHaveBeenCalledWith(
+        toTenantId('tenantId1'),
+        toGroupId('groupId1'),
+        'groupUserId1',
+      )
       expect(notificationMock.success).toHaveBeenCalledWith(
         'Member successfully removed from this group',
         'Member Removed',
       )
     })
 
-    it('shows error notification when removeGroupMember fails', async () => {
+    it('shows error notification when removeGroupUser fails', async () => {
       groupStore.removeGroupUser = vi.fn().mockRejectedValue(new Error('fail'))
 
-      renderComponent()
-
-      await fireEvent.click(screen.getByRole('button', { name: 'stub-delete' }))
+      const wrapper = mountComponent('groupId1', 'tenantId1')
+      await child(wrapper).vm.$emit('delete', 'groupUserId1')
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to remove member from group',
@@ -225,124 +204,143 @@ describe('GroupMemberContainer', () => {
         .mockResolvedValue([makeUser({ id: toUserId('idirEmail') })])
       userStore.searchBCeIDDisplayName = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('BCeIDDisplayName') })])
+        .mockResolvedValue([makeUser({ id: toUserId('bceidDisplayName') })])
       userStore.searchBCeIDEmail = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('BCeIDEmail') })])
+        .mockResolvedValue([makeUser({ id: toUserId('bceidEmail') })])
     })
 
     it('searches by first name and concatenates BCeID display name results', async () => {
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-first-name' }),
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.FIRST_NAME.value,
+        'firstName',
       )
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirFirstName).toHaveBeenCalledWith('firstName')
       expect(userStore.searchBCeIDDisplayName).toHaveBeenCalledWith('firstName')
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent('2')
+      expect(child(wrapper).props('searchResults')).toEqual([
+        expect.objectContaining({ id: toUserId('idirFirstName') }),
+        expect.objectContaining({ id: toUserId('bceidDisplayName') }),
+      ])
     })
 
     it('searches by last name and concatenates BCeID display name results', async () => {
-      renderComponent()
-
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-last-name' }),
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.LAST_NAME.value,
+        'lastName',
       )
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirLastName).toHaveBeenCalledWith('lastName')
       expect(userStore.searchBCeIDDisplayName).toHaveBeenCalledWith('lastName')
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent('2')
+      expect(child(wrapper).props('searchResults')).toEqual([
+        expect.objectContaining({ id: toUserId('idirLastName') }),
+        expect.objectContaining({ id: toUserId('bceidDisplayName') }),
+      ])
     })
 
     it('searches by email and concatenates BCeID email results', async () => {
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-email' }),
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.EMAIL.value,
+        'email@example.com',
       )
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirEmail).toHaveBeenCalledWith(
-        'firstName.lastName@gov.bc.ca',
+        'email@example.com',
       )
       expect(userStore.searchBCeIDEmail).toHaveBeenCalledWith(
-        'firstName.lastName@gov.bc.ca',
+        'email@example.com',
       )
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent('2')
+      expect(child(wrapper).props('searchResults')).toEqual([
+        expect.objectContaining({ id: toUserId('idirEmail') }),
+        expect.objectContaining({ id: toUserId('bceidEmail') }),
+      ])
     })
 
-    it('throws when search type is invalid', async () => {
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-invalid-search' }),
-      )
-      await nextTick()
+    it('shows an error when an invalid search type is provided', async () => {
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit('search', 'invalidSearch', 'invalidSearch')
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith('User search failed')
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent(
-        'null',
-      )
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
 
     it('shows error and nulls results when search throws', async () => {
       userStore.searchIdirFirstName = vi
         .fn()
-        .mockRejectedValue(new Error('network'))
+        .mockRejectedValue(new Error('message'))
 
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-first-name' }),
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.FIRST_NAME.value,
+        'firstName',
       )
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith('User search failed')
-      expect(screen.getByTestId('search-results-count')).toHaveTextContent(
-        'null',
-      )
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
 
-    it('resets isLoadingSearch to false after search completes', async () => {
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-email' }),
+    it('resets loadingSearch to false after search completes', async () => {
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.EMAIL.value,
+        'email@example.com',
       )
-      await nextTick()
+      await flushPromises()
 
-      expect(screen.getByTestId('loading-search')).toHaveTextContent('false')
+      expect(child(wrapper).props('loadingSearch')).toBe(false)
     })
 
-    it('resets isLoadingSearch to false even when search throws', async () => {
+    it('resets loadingSearch to false even when search throws', async () => {
       userStore.searchIdirEmail = vi.fn().mockRejectedValue(new Error('fail'))
 
-      renderComponent()
-      await fireEvent.click(
-        screen.getByRole('button', { name: 'stub-search-email' }),
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.EMAIL.value,
+        'email@example.com',
       )
-      await nextTick()
+      await flushPromises()
 
-      expect(screen.getByTestId('loading-search')).toHaveTextContent('false')
+      expect(child(wrapper).props('loadingSearch')).toBe(false)
     })
   })
 
-  it('sets searchResults to null on cancel', async () => {
-    userStore.searchIdirEmail = vi
-      .fn()
-      .mockResolvedValue([makeUser({ id: toUserId('a') })])
-    userStore.searchBCeIDEmail = vi
-      .fn()
-      .mockResolvedValue([makeUser({ id: toUserId('b') })])
+  describe('@cancel inline handler', () => {
+    it('sets searchResults to null on cancel', async () => {
+      userStore.searchIdirEmail = vi
+        .fn()
+        .mockResolvedValue([makeUser({ id: toUserId('userId1') })])
+      userStore.searchBCeIDEmail = vi
+        .fn()
+        .mockResolvedValue([makeUser({ id: toUserId('userId2') })])
 
-    renderComponent()
-    await fireEvent.click(
-      screen.getByRole('button', { name: 'stub-search-email' }),
-    )
-    await nextTick()
+      const wrapper = mountComponent()
+      await child(wrapper).vm.$emit(
+        'search',
+        IDIR_SEARCH_TYPE.EMAIL.value,
+        'email@example.com',
+      )
+      await flushPromises()
 
-    expect(screen.getByTestId('search-results-count')).toHaveTextContent('2')
+      expect(child(wrapper).props('searchResults')).toHaveLength(2)
 
-    await fireEvent.click(screen.getByRole('button', { name: 'stub-cancel' }))
+      await child(wrapper).vm.$emit('cancel')
+      await flushPromises()
 
-    expect(screen.getByTestId('search-results-count')).toHaveTextContent('null')
+      expect(child(wrapper).props('searchResults')).toBeNull()
+    })
   })
 })

--- a/frontend/src/__tests__/components/route/TenantHeaderContainer.test.ts
+++ b/frontend/src/__tests__/components/route/TenantHeaderContainer.test.ts
@@ -1,0 +1,138 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+import { makeTenant } from '@/__tests__/__factories__'
+
+import TenantContainer from '@/components/route/TenantHeaderContainer.vue'
+import { toTenantId } from '@/models/tenant.model'
+import { useGroupStore } from '@/stores/useGroupStore'
+import { useTenantStore } from '@/stores/useTenantStore'
+
+import { useNotification } from '@/composables/useNotification'
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: vi.fn(),
+}))
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    {
+      children: [
+        {
+          path: '',
+          component: { template: '<div />' },
+        },
+      ],
+      component: TenantContainer,
+      path: '/tenants/:tenantId',
+    },
+    {
+      children: [
+        {
+          path: '',
+          component: { template: '<div />' },
+        },
+      ],
+      component: TenantContainer,
+      path: '/tenants/:tenantId/group/:groupId',
+    },
+  ],
+})
+
+const mountComponent = () =>
+  mount(TenantContainer, {
+    global: {
+      plugins: [router],
+      stubs: {
+        LoadingWrapper: { template: '<div><slot /></div>' },
+        LoginContainer: { template: '<div><slot /></div>' },
+        TenantHeader: true,
+      },
+    },
+    props: {
+      tenantId: toTenantId('tenantId1'),
+    },
+  })
+
+describe('TenantContainer', () => {
+  let groupStore: ReturnType<typeof useGroupStore>
+  let tenantStore: ReturnType<typeof useTenantStore>
+  let notificationMock: ReturnType<typeof useNotification>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+
+    groupStore = useGroupStore()
+    groupStore.groups = []
+
+    tenantStore = useTenantStore()
+    tenantStore.tenants = [makeTenant({ id: toTenantId('tenantId1') })]
+
+    notificationMock = {
+      items: [],
+
+      error: vi.fn(),
+      info: vi.fn(),
+      remove: vi.fn(),
+      success: vi.fn(),
+      warning: vi.fn(),
+    }
+    vi.mocked(useNotification).mockReturnValue(notificationMock)
+  })
+
+  it('fetches groups and tenant on mount', async () => {
+    groupStore.fetchGroups = vi.fn().mockResolvedValue(undefined)
+    tenantStore.fetchTenant = vi.fn().mockResolvedValue(undefined)
+
+    mountComponent()
+    await flushPromises()
+
+    expect(groupStore.fetchGroups).toHaveBeenCalledWith(toTenantId('tenantId1'))
+    expect(tenantStore.fetchTenant).toHaveBeenCalledWith(
+      toTenantId('tenantId1'),
+    )
+  })
+
+  it('does not render TenantHeader when groupId exists', async () => {
+    await router.push('/tenants/tenantId1/group/groupId1')
+    await router.isReady()
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TenantHeader' }).exists()).toBe(false)
+  })
+
+  it('renders the child route', async () => {
+    await router.push('/tenants/tenantId1')
+    await router.isReady()
+
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'TenantHeader' }).exists()).toBe(true)
+  })
+
+  it('shows an error when loading groups fails', async () => {
+    groupStore.fetchGroups = vi.fn().mockRejectedValue(new Error())
+    tenantStore.fetchTenant = vi.fn().mockResolvedValue(undefined)
+
+    mountComponent()
+    await flushPromises()
+
+    expect(notificationMock.error).toHaveBeenCalledWith('Failed to load groups')
+  })
+
+  it('shows an error when loading tenant fails', async () => {
+    groupStore.fetchGroups = vi.fn().mockResolvedValue(undefined)
+    tenantStore.fetchTenant = vi.fn().mockRejectedValue(new Error())
+
+    mountComponent()
+    await flushPromises()
+
+    expect(notificationMock.error).toHaveBeenCalledWith('Failed to load tenant')
+  })
+})

--- a/frontend/src/__tests__/components/route/TenantListContainer.test.ts
+++ b/frontend/src/__tests__/components/route/TenantListContainer.test.ts
@@ -1,5 +1,4 @@
-import { mount, flushPromises } from '@vue/test-utils'
-import { createPinia, setActivePinia } from 'pinia'
+import { flushPromises, mount } from '@vue/test-utils'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRouter, createWebHistory } from 'vue-router'
 
@@ -21,6 +20,7 @@ import { useNotification } from '@/composables/useNotification'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
 import { toTenantId } from '@/models/tenant.model'
 import vuetify from '@/plugins/vuetify'
+import { DomainError } from '@/errors/domain/DomainError'
 
 let currentAuthStore = createMockAuthStore()
 
@@ -32,6 +32,7 @@ beforeEach(() => {
   currentAuthStore = createMockAuthStore()
   mockTenantRequestStore()
   mockTenantStore()
+  vi.clearAllMocks()
 })
 
 const mockError = vi.fn()
@@ -44,21 +45,69 @@ vi.mock('@/composables/useNotification', () => ({
   }),
 }))
 
-const router = createRouter({
-  history: createWebHistory(),
-  routes: [{ path: '/:pathMatch(.*)*', component: { template: '<div />' } }],
-})
+const buttonPrimaryStub = {
+  emits: ['click'],
+  name: 'ButtonPrimary',
+  template: `
+    <button @click="$emit('click')">
+      Request a Tenant
+    </button>
+  `,
+}
+
+const tenantListStub = {
+  emits: ['select'],
+  name: 'TenantList',
+  props: ['tenants'],
+  template: `
+    <div>
+      <button @click="$emit('select', 'tenantId1')">
+        tenant
+      </button>
+    </div>
+  `,
+}
+
+const tenantRequestDialogStub = {
+  emits: ['clear-duplicate-error', 'submit', 'update:modelValue'],
+  name: 'TenantRequestDialog',
+  props: ['isDuplicateName', 'modelValue'],
+  template: `
+    <div>
+      <button @click="$emit('submit', {})">
+        submit
+      </button>
+      <button @click="$emit('update:modelValue', false)">
+        close
+      </button>
+      <button @click="$emit('clear-duplicate-error')">
+        clear
+      </button>
+    </div>
+  `,
+}
+
+const createTestRouter = () =>
+  createRouter({
+    history: createWebHistory(),
+    routes: [
+      {
+        path: '/:pathMatch(.*)*',
+        component: { template: '<div />' },
+      },
+    ],
+  })
 
 const mountComponent = () =>
   mount(TenantListContainer, {
     global: {
-      plugins: [createPinia(), router, vuetify],
+      plugins: [createTestRouter(), vuetify],
       stubs: {
-        LoginContainer: { template: '<div><slot /></div>' },
+        ButtonPrimary: buttonPrimaryStub,
         LoadingWrapper: { template: '<div><slot /></div>' },
-        TenantList: true,
-        TenantRequestDialog: true,
-        ButtonPrimary: true,
+        LoginContainer: { template: '<div><slot /></div>' },
+        TenantList: tenantListStub,
+        TenantRequestDialog: tenantRequestDialogStub,
       },
     },
   })
@@ -66,12 +115,6 @@ const mountComponent = () =>
 // --- Tests -------------------------------------------------------------------
 
 describe('TenantListContainer.vue', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-    mockTenantRequestStore()
-    mockTenantStore()
-  })
-
   describe('onMounted', () => {
     it('fetches tenants on mount', async () => {
       const user = makeUser()
@@ -86,7 +129,7 @@ describe('TenantListContainer.vue', () => {
     })
 
     it('shows an error notification if fetching tenants fails', async () => {
-      mockTenantStoreFetchError(new Error('oops'))
+      mockTenantStoreFetchError(new Error('message'))
       mountComponent()
       await flushPromises()
 
@@ -96,17 +139,17 @@ describe('TenantListContainer.vue', () => {
 
   describe('navigation', () => {
     it('navigates to the tenant users page when a card is selected', async () => {
-      mockTenantStore([makeTenant({ id: toTenantId('tenant-1') })])
-      await router.isReady()
+      mockTenantStore([makeTenant({ id: toTenantId('tenantId1') })])
       const wrapper = mountComponent()
+      const router = wrapper.vm.$router
       await flushPromises()
 
       await wrapper
         .findComponent({ name: 'TenantList' })
-        .vm.$emit('select', 'tenant-1')
+        .vm.$emit('select', 'tenantId1')
       await flushPromises()
 
-      expect(router.currentRoute.value.path).toBe('/tenants/tenant-1/users')
+      expect(router.currentRoute.value.path).toBe('/tenants/tenantId1/users')
     })
   })
 
@@ -115,12 +158,37 @@ describe('TenantListContainer.vue', () => {
       const wrapper = mountComponent()
 
       await wrapper.findComponent({ name: 'ButtonPrimary' }).trigger('click')
+      await flushPromises()
 
       expect(
         wrapper
           .findComponent({ name: 'TenantRequestDialog' })
           .props('modelValue'),
       ).toBe(true)
+    })
+
+    it('closes the dialog when update:modelValue is emitted', async () => {
+      const wrapper = mountComponent()
+
+      await wrapper.findComponent({ name: 'ButtonPrimary' }).trigger('click')
+      await flushPromises()
+
+      expect(
+        wrapper
+          .findComponent({ name: 'TenantRequestDialog' })
+          .props('modelValue'),
+      ).toBe(true)
+
+      await wrapper
+        .findComponent({ name: 'TenantRequestDialog' })
+        .vm.$emit('update:modelValue', false)
+      await flushPromises()
+
+      expect(
+        wrapper
+          .findComponent({ name: 'TenantRequestDialog' })
+          .props('modelValue'),
+      ).toBe(false)
     })
 
     it('submits a tenant request and closes the dialog', async () => {
@@ -153,7 +221,11 @@ describe('TenantListContainer.vue', () => {
     it('sets isDuplicateName when a DuplicateEntityError is thrown', async () => {
       mockTenantRequestStoreError(new DuplicateEntityError('oops'))
       const wrapper = mountComponent()
-      const details = { name: 'Duplicate', description: '', ministryName: '' }
+      const details = {
+        description: 'description',
+        ministryName: 'ministryName',
+        name: 'name',
+      }
 
       await wrapper
         .findComponent({ name: 'TenantRequestDialog' })
@@ -165,6 +237,72 @@ describe('TenantListContainer.vue', () => {
           .findComponent({ name: 'TenantRequestDialog' })
           .props('isDuplicateName'),
       ).toBe(true)
+    })
+
+    it('clears the duplicate name error when requested by the dialog', async () => {
+      mockTenantRequestStoreError(new DuplicateEntityError('oops'))
+      const wrapper = mountComponent()
+      const details = {
+        description: 'description',
+        ministryName: 'ministryName',
+        name: 'name',
+      }
+
+      await wrapper
+        .findComponent({ name: 'TenantRequestDialog' })
+        .vm.$emit('submit', details)
+      await flushPromises()
+
+      expect(
+        wrapper
+          .findComponent({ name: 'TenantRequestDialog' })
+          .props('isDuplicateName'),
+      ).toBe(true)
+
+      await wrapper
+        .findComponent({ name: 'TenantRequestDialog' })
+        .vm.$emit('clear-duplicate-error')
+      await flushPromises()
+
+      expect(
+        wrapper
+          .findComponent({ name: 'TenantRequestDialog' })
+          .props('isDuplicateName'),
+      ).toBe(false)
+    })
+
+    it('shows an error notification on DomainError with userMessage', async () => {
+      mockTenantRequestStoreError(new DomainError('message', 'userMessage'))
+      const wrapper = mountComponent()
+      const details = {
+        description: 'description',
+        ministryName: 'ministryName',
+        name: 'name',
+      }
+
+      await wrapper
+        .findComponent({ name: 'TenantRequestDialog' })
+        .vm.$emit('submit', details)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('userMessage')
+    })
+
+    it('shows an error notification on DomainError without userMessage', async () => {
+      mockTenantRequestStoreError(new DomainError('message'))
+      const wrapper = mountComponent()
+      const details = {
+        description: 'description',
+        ministryName: 'ministryName',
+        name: 'name',
+      }
+
+      await wrapper
+        .findComponent({ name: 'TenantRequestDialog' })
+        .vm.$emit('submit', details)
+      await flushPromises()
+
+      expect(mockError).toHaveBeenCalledWith('Failed to create the new tenant')
     })
   })
 })

--- a/frontend/src/__tests__/components/route/TenantServiceContainer.test.ts
+++ b/frontend/src/__tests__/components/route/TenantServiceContainer.test.ts
@@ -1,0 +1,295 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { makeService, makeTenant } from '@/__tests__/__factories__'
+
+import TenantServiceContainer from '@/components/route/TenantServiceContainer.vue'
+import { useNotification } from '@/composables/useNotification'
+import { toServiceId } from '@/models/service.model'
+import { toTenantId } from '@/models/tenant.model'
+import vuetify from '@/plugins/vuetify'
+import { useServiceStore } from '@/stores/useServiceStore'
+import { useTenantStore } from '@/stores/useTenantStore'
+
+vi.mock('@/composables/useNotification', () => ({
+  useNotification: vi.fn(),
+}))
+
+const loginContainerStub = {
+  name: 'LoginContainer',
+  template: '<div><slot /></div>',
+}
+
+const loadingWrapperStub = {
+  name: 'LoadingWrapper',
+  props: ['loading', 'loadingMessage'],
+  template: '<div><slot v-if="!loading" /></div>',
+}
+
+const child = (wrapper: ReturnType<typeof mountComponent>) => {
+  return wrapper.getComponent({ name: 'ServiceManagement' })
+}
+
+const mountComponent = (tenantId = 'tenantId1') => {
+  return mount(TenantServiceContainer, {
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        LoginContainer: loginContainerStub,
+        LoadingWrapper: loadingWrapperStub,
+        ServiceManagement: true,
+      },
+    },
+    props: { tenantId: toTenantId(tenantId) },
+  })
+}
+
+describe('TenantServiceContainer', () => {
+  let serviceStore: ReturnType<typeof useServiceStore>
+  let tenantStore: ReturnType<typeof useTenantStore>
+  let notificationMock: ReturnType<typeof useNotification>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    serviceStore = useServiceStore()
+    tenantStore = useTenantStore()
+
+    tenantStore.getTenant = vi
+      .fn()
+      .mockReturnValue(makeTenant({ id: toTenantId('tenantId1') }))
+
+    serviceStore.fetchServices = vi.fn().mockResolvedValue(undefined)
+    serviceStore.fetchTenantServices = vi.fn().mockResolvedValue(undefined)
+
+    notificationMock = {
+      success: vi.fn(),
+      error: vi.fn(),
+      warning: vi.fn(),
+      info: vi.fn(),
+      remove: vi.fn(),
+      items: [],
+    }
+    vi.mocked(useNotification).mockReturnValue(notificationMock)
+  })
+
+  describe('tenant computed', () => {
+    it('reports an error when the tenant cannot be found', async () => {
+      tenantStore.getTenant = vi.fn().mockReturnValue(undefined)
+      const errorHandler = vi.fn()
+
+      mount(TenantServiceContainer, {
+        global: {
+          plugins: [vuetify],
+          stubs: {
+            LoginContainer: loginContainerStub,
+            LoadingWrapper: loadingWrapperStub,
+            ServiceManagement: true,
+          },
+          config: { errorHandler },
+        },
+        props: { tenantId: toTenantId('tenantId1') },
+      })
+      await flushPromises()
+
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Tenant tenantId1 not found' }),
+        expect.anything(),
+        expect.any(String),
+      )
+    })
+  })
+
+  describe('init', () => {
+    it('calls fetchServices and fetchTenantServices on mount', async () => {
+      mountComponent()
+      await flushPromises()
+
+      expect(serviceStore.fetchServices).toHaveBeenCalled()
+      expect(serviceStore.fetchTenantServices).toHaveBeenCalledWith(
+        toTenantId('tenantId1'),
+      )
+    })
+
+    it('does not render ServiceManagement until both fetches settle', async () => {
+      let resolveServices!: () => void
+      serviceStore.fetchServices = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveServices = () => resolve()
+          }),
+      )
+
+      const wrapper = mountComponent()
+
+      expect(
+        wrapper.findComponent({ name: 'ServiceManagement' }).exists(),
+      ).toBe(false)
+
+      resolveServices()
+      await flushPromises()
+
+      expect(
+        wrapper.findComponent({ name: 'ServiceManagement' }).exists(),
+      ).toBe(true)
+    })
+
+    it('shows error notification when fetchServices fails', async () => {
+      serviceStore.fetchServices = vi.fn().mockRejectedValue(new Error('fail'))
+
+      mountComponent()
+      await flushPromises()
+
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        'Failed to load services',
+      )
+    })
+
+    it('shows error notification when fetchTenantServices fails', async () => {
+      serviceStore.fetchTenantServices = vi
+        .fn()
+        .mockRejectedValue(new Error('fail'))
+
+      mountComponent()
+      await flushPromises()
+
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        'Failed to load tenant services',
+      )
+    })
+
+    it('shows both error notifications when both fetches fail', async () => {
+      serviceStore.fetchServices = vi.fn().mockRejectedValue(new Error('fail'))
+      serviceStore.fetchTenantServices = vi
+        .fn()
+        .mockRejectedValue(new Error('fail'))
+
+      mountComponent()
+      await flushPromises()
+
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        'Failed to load services',
+      )
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        'Failed to load tenant services',
+      )
+    })
+
+    it('sets initialized even when both fetches fail', async () => {
+      serviceStore.fetchServices = vi.fn().mockRejectedValue(new Error('fail'))
+      serviceStore.fetchTenantServices = vi
+        .fn()
+        .mockRejectedValue(new Error('fail'))
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      expect(
+        wrapper.findComponent({ name: 'ServiceManagement' }).exists(),
+      ).toBe(true)
+    })
+  })
+
+  describe('services computed', () => {
+    it('passes services sorted alphabetically by displayName', async () => {
+      serviceStore.services = [
+        makeService({ displayName: 'Zebra Service' }),
+        makeService({ displayName: 'Apple Service' }),
+        makeService({ displayName: 'Mango Service' }),
+      ]
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      expect(
+        child(wrapper)
+          .props('services')
+          .map((s: { displayName: string }) => s.displayName),
+      ).toEqual(['Apple Service', 'Mango Service', 'Zebra Service'])
+    })
+  })
+
+  describe('tenantServices computed', () => {
+    it('passes tenant services sorted alphabetically by displayName', async () => {
+      serviceStore.tenantServices = [
+        makeService({ displayName: 'Zebra Service' }),
+        makeService({ displayName: 'Apple Service' }),
+      ]
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      expect(
+        child(wrapper)
+          .props('tenantServices')
+          .map((s: { displayName: string }) => s.displayName),
+      ).toEqual(['Apple Service', 'Zebra Service'])
+    })
+  })
+
+  describe('handleAddService', () => {
+    it('calls addServiceToTenant, adds service to tenantServices, and shows success notification', async () => {
+      const service = makeService({
+        id: toServiceId('service1'),
+        displayName: 'My Service',
+      })
+      serviceStore.services = [service]
+      serviceStore.tenantServices = []
+      serviceStore.addServiceToTenant = vi.fn().mockResolvedValue(undefined)
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      await child(wrapper).vm.$emit('add-service', service.id)
+      await flushPromises()
+
+      expect(serviceStore.addServiceToTenant).toHaveBeenCalledWith(
+        toTenantId('tenantId1'),
+        service.id,
+      )
+      expect(notificationMock.success).toHaveBeenCalledWith(
+        'My Service has been added to this tenant.',
+      )
+      expect(
+        child(wrapper)
+          .props('tenantServices')
+          .map((s: { id: string }) => s.id),
+      ).toContain(service.id)
+    })
+
+    it('does not update tenantServices or notify success when the added service is not found locally', async () => {
+      serviceStore.services = []
+      serviceStore.tenantServices = []
+      serviceStore.addServiceToTenant = vi.fn().mockResolvedValue(undefined)
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      await child(wrapper).vm.$emit(
+        'add-service',
+        toServiceId('unknownService'),
+      )
+      await flushPromises()
+
+      expect(serviceStore.addServiceToTenant).toHaveBeenCalled()
+      expect(notificationMock.success).not.toHaveBeenCalled()
+      expect(child(wrapper).props('tenantServices')).toEqual([])
+    })
+
+    it('shows error notification when addServiceToTenant fails', async () => {
+      serviceStore.addServiceToTenant = vi
+        .fn()
+        .mockRejectedValue(new Error('fail'))
+
+      const wrapper = mountComponent()
+      await flushPromises()
+
+      await child(wrapper).vm.$emit('add-service', toServiceId('service1'))
+      await flushPromises()
+
+      expect(notificationMock.error).toHaveBeenCalledWith(
+        'Failed to add service to tenant',
+      )
+    })
+  })
+})

--- a/frontend/src/__tests__/components/route/TenantUserContainer.test.ts
+++ b/frontend/src/__tests__/components/route/TenantUserContainer.test.ts
@@ -1,7 +1,6 @@
-import { mount } from '@vue/test-utils'
+import { flushPromises, mount } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
 
 import {
   makeGroup,
@@ -16,25 +15,43 @@ import { useNotification } from '@/composables/useNotification'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
 import { toGroupId } from '@/models/group.model'
 import { toTenantId } from '@/models/tenant.model'
+import { toUserId } from '@/models/user.model'
 import vuetify from '@/plugins/vuetify'
 import { useGroupStore } from '@/stores/useGroupStore'
 import { useRoleStore } from '@/stores/useRoleStore'
 import { useTenantStore } from '@/stores/useTenantStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { IDIR_SEARCH_TYPE } from '@/utils/constants'
-import { toUserId } from '@/models/user.model'
 
 vi.mock('@/composables/useNotification', () => ({
   useNotification: vi.fn(),
 }))
 
+const loginContainerStub = {
+  name: 'LoginContainer',
+  template: '<div><slot /></div>',
+}
+
+const loadingWrapperStub = {
+  name: 'LoadingWrapper',
+  props: ['loading', 'loadingMessage'],
+  template: '<div><slot /></div>',
+}
+
 const child = (wrapper: ReturnType<typeof mountComponent>) => {
   return wrapper.getComponent({ name: 'TenantUserManagement' })
 }
 
-const mountComponent = (tenantId = 't-1') => {
+const mountComponent = (tenantId = 'tenantId1') => {
   return mount(TenantUserContainer, {
-    global: { plugins: [vuetify], stubs: { TenantUserManagement: true } },
+    global: {
+      plugins: [vuetify],
+      stubs: {
+        LoadingWrapper: loadingWrapperStub,
+        LoginContainer: loginContainerStub,
+        TenantUserManagement: true,
+      },
+    },
     props: { tenantId: toTenantId(tenantId) },
   })
 }
@@ -54,7 +71,7 @@ describe('TenantUserContainer', () => {
     userStore = useUserStore()
 
     tenantStore = useTenantStore()
-    tenantStore.tenants = [makeTenant({ id: toTenantId('t-1') })]
+    tenantStore.tenants = [makeTenant({ id: toTenantId('tenantId1') })]
 
     notificationMock = {
       success: vi.fn(),
@@ -70,12 +87,16 @@ describe('TenantUserContainer', () => {
     roleStore.fetchRoles = vi.fn().mockResolvedValue(undefined)
   })
 
-  // --- onMounted -------------------------------------------------------------
-
   describe('onMounted', () => {
+    it('throws an error when the tenant cannot be found', () => {
+      tenantStore.tenants = []
+
+      expect(() => mountComponent()).toThrow('Tenant tenantId1 not found')
+    })
+
     it('calls fetchRoles on mount', async () => {
       mountComponent()
-      await nextTick()
+      await flushPromises()
 
       expect(roleStore.fetchRoles).toHaveBeenCalled()
     })
@@ -84,8 +105,7 @@ describe('TenantUserContainer', () => {
       roleStore.fetchRoles = vi.fn().mockRejectedValue(new Error('fail'))
 
       mountComponent()
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to load roles',
@@ -93,7 +113,38 @@ describe('TenantUserContainer', () => {
     })
   })
 
-  // --- roles computed --------------------------------------------------------
+  describe('loading computed', () => {
+    it('does not render TenantUserManagement until roles are loaded', async () => {
+      let resolveRoles!: () => void
+      roleStore.fetchRoles = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveRoles = () => resolve()
+          }),
+      )
+      const wrapper = mount(TenantUserContainer, {
+        global: {
+          plugins: [vuetify],
+          stubs: {
+            LoginContainer: loginContainerStub,
+            TenantUserManagement: true,
+          },
+        },
+        props: { tenantId: toTenantId('tenantId1') },
+      })
+
+      expect(
+        wrapper.findComponent({ name: 'TenantUserManagement' }).exists(),
+      ).toBe(false)
+
+      resolveRoles()
+      await flushPromises()
+
+      expect(
+        wrapper.findComponent({ name: 'TenantUserManagement' }).exists(),
+      ).toBe(true)
+    })
+  })
 
   describe('roles computed', () => {
     it('passes roleStore.roles down as possible-roles prop', async () => {
@@ -101,27 +152,24 @@ describe('TenantUserContainer', () => {
       roleStore.roles = roles
 
       const wrapper = mountComponent()
-      await nextTick()
+      await flushPromises()
 
       expect(child(wrapper).props('possibleRoles')).toEqual(roles)
     })
   })
 
-  // --- handleAddUser ---------------------------------------------------------
-
   describe('handleAddUser', () => {
     it('calls addTenantUser, clears searchResults, and shows success notification', async () => {
       const user = makeUser()
       tenantStore.addTenantUser = vi.fn().mockResolvedValue(undefined)
-      const tenantId = 'tenant-1'
+      const tenantId = 'tenantId1'
       const tenant = makeTenant({ id: toTenantId(tenantId) })
       tenantStore.tenants.push(tenant)
       groupStore.addGroupUser = vi.fn().mockResolvedValue(undefined)
 
       const wrapper = mountComponent(tenantId)
       await child(wrapper).vm.$emit('add', user, [])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(tenantStore.addTenantUser).toHaveBeenCalledWith(tenantId, user)
       expect(notificationMock.success).toHaveBeenCalledWith(
@@ -134,25 +182,32 @@ describe('TenantUserContainer', () => {
     it('adds user to each provided group and shows group success notification', async () => {
       const user = makeUser()
       const groups = [
-        makeGroup({ id: toGroupId('g1') }),
-        makeGroup({ id: toGroupId('g2') }),
+        makeGroup({ id: toGroupId('groupId1') }),
+        makeGroup({ id: toGroupId('groupId2') }),
       ]
       tenantStore.addTenantUser = vi.fn().mockResolvedValue(undefined)
-      const tenantId = 'tenant-1'
+      const tenantId = 'tenantId1'
       const tenant = makeTenant({ id: toTenantId(tenantId) })
       tenantStore.tenants.push(tenant)
       groupStore.addGroupUser = vi.fn().mockResolvedValue(undefined)
 
       const wrapper = mountComponent(tenantId)
       await child(wrapper).vm.$emit('add', user, groups)
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(groupStore.addGroupUser).toHaveBeenCalledTimes(2)
-      expect(groupStore.addGroupUser).toHaveBeenCalledWith(tenantId, 'g1', user)
-      expect(groupStore.addGroupUser).toHaveBeenCalledWith(tenantId, 'g2', user)
+      expect(groupStore.addGroupUser).toHaveBeenCalledWith(
+        tenantId,
+        'groupId1',
+        user,
+      )
+      expect(groupStore.addGroupUser).toHaveBeenCalledWith(
+        tenantId,
+        'groupId2',
+        user,
+      )
       expect(notificationMock.success).toHaveBeenCalledWith(
-        'New user succesfully added to groups',
+        'New user successfully added to groups',
         'User Added to Groups',
       )
     })
@@ -160,15 +215,14 @@ describe('TenantUserContainer', () => {
     it('does not show group success notification when groups array is empty', async () => {
       const user = makeUser()
       tenantStore.addTenantUser = vi.fn().mockResolvedValue(undefined)
-      const tenantId = 'tenant-1'
+      const tenantId = 'tenantId1'
       const tenant = makeTenant({ id: toTenantId(tenantId) })
       tenantStore.tenants.push(tenant)
       groupStore.addGroupUser = vi.fn().mockResolvedValue(undefined)
 
       const wrapper = mountComponent(tenantId)
       await child(wrapper).vm.$emit('add', user, [])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       const groupSuccessCalls = vi
         .mocked(notificationMock.success)
@@ -186,8 +240,7 @@ describe('TenantUserContainer', () => {
 
       const wrapper = mountComponent()
       await child(wrapper).vm.$emit('add', user, [])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         expect.stringContaining('Jane Doe'),
@@ -202,8 +255,7 @@ describe('TenantUserContainer', () => {
 
       const wrapper = mountComponent()
       await child(wrapper).vm.$emit('add', makeUser(), [])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith('Failed to add user')
     })
@@ -214,8 +266,7 @@ describe('TenantUserContainer', () => {
 
       const wrapper = mountComponent()
       await child(wrapper).vm.$emit('add', makeUser(), [makeGroup()])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(groupStore.addGroupUser).not.toHaveBeenCalled()
     })
@@ -228,16 +279,13 @@ describe('TenantUserContainer', () => {
 
       const wrapper = mountComponent()
       await child(wrapper).vm.$emit('add', makeUser(), [makeGroup()])
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to add user to groups',
       )
     })
   })
-
-  // --- handleClearSearch -----------------------------------------------------
 
   describe('handleClearSearch', () => {
     it('sets searchResults to null', async () => {
@@ -254,17 +302,14 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.EMAIL.value,
         'x@x.com',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       await child(wrapper).vm.$emit('clear-search')
-      await nextTick()
+      await flushPromises()
 
       expect(child(wrapper).props('searchResults')).toBeNull()
     })
   })
-
-  // --- cancel inline handler -------------------------------------------------
 
   describe('@cancel inline handler', () => {
     it('sets searchResults to null on cancel', async () => {
@@ -281,17 +326,14 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.EMAIL.value,
         'x@x.com',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       await child(wrapper).vm.$emit('cancel')
-      await nextTick()
+      await flushPromises()
 
       expect(child(wrapper).props('searchResults')).toBeNull()
     })
   })
-
-  // --- handleRemoveRole ------------------------------------------------------
 
   describe('handleRemoveRole', () => {
     it('calls removeTenantUserRole and shows success notification', async () => {
@@ -301,14 +343,13 @@ describe('TenantUserContainer', () => {
       tenantStore.tenants.push(tenant)
 
       const wrapper = mountComponent(tenantId)
-      await child(wrapper).vm.$emit('remove-role', 'u1', 'r1')
-      await nextTick()
-      await nextTick()
+      await child(wrapper).vm.$emit('remove-role', 'userId1', 'roleId1')
+      await flushPromises()
 
       expect(tenantStore.removeTenantUserRole).toHaveBeenCalledWith(
         tenantId,
-        'u1',
-        'r1',
+        'userId1',
+        'roleId1',
       )
       expect(notificationMock.success).toHaveBeenCalledWith(
         'The role was successfully removed from the user',
@@ -322,9 +363,8 @@ describe('TenantUserContainer', () => {
         .mockRejectedValue(new Error('fail'))
 
       const wrapper = mountComponent()
-      await child(wrapper).vm.$emit('remove-role', 'u1', 'r1')
-      await nextTick()
-      await nextTick()
+      await child(wrapper).vm.$emit('remove-role', 'userId1', 'roleId1')
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to remove user role',
@@ -332,21 +372,21 @@ describe('TenantUserContainer', () => {
     })
   })
 
-  // --- handleRemoveUser ------------------------------------------------------
-
   describe('handleRemoveUser', () => {
     it('calls removeTenantUser and shows success notification', async () => {
       tenantStore.removeTenantUser = vi.fn().mockResolvedValue(undefined)
-      const tenantId = 'tenant-1'
+      const tenantId = 'tenantId1'
       const tenant = makeTenant({ id: toTenantId(tenantId) })
       tenantStore.tenants.push(tenant)
 
       const wrapper = mountComponent(tenantId)
-      await child(wrapper).vm.$emit('remove-user', 'u1')
-      await nextTick()
-      await nextTick()
+      await child(wrapper).vm.$emit('remove-user', 'userId1')
+      await flushPromises()
 
-      expect(tenantStore.removeTenantUser).toHaveBeenCalledWith(tenantId, 'u1')
+      expect(tenantStore.removeTenantUser).toHaveBeenCalledWith(
+        tenantId,
+        'userId1',
+      )
       expect(notificationMock.success).toHaveBeenCalledWith(
         'The user was successfully removed',
         'User Removed',
@@ -359,9 +399,8 @@ describe('TenantUserContainer', () => {
         .mockRejectedValue(new Error('fail'))
 
       const wrapper = mountComponent()
-      await child(wrapper).vm.$emit('remove-user', 'u1')
-      await nextTick()
-      await nextTick()
+      await child(wrapper).vm.$emit('remove-user', 'userId1')
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith(
         'Failed to remove user',
@@ -373,8 +412,7 @@ describe('TenantUserContainer', () => {
 
       const wrapper = mountComponent()
       await child(wrapper).vm.$emit('remove-user', undefined)
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(tenantStore.removeTenantUser).not.toHaveBeenCalled()
       expect(notificationMock.error).toHaveBeenCalledWith(
@@ -383,25 +421,23 @@ describe('TenantUserContainer', () => {
     })
   })
 
-  // --- handleUserSearch ------------------------------------------------------
-
   describe('handleUserSearch', () => {
     beforeEach(() => {
       userStore.searchIdirFirstName = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('a') })])
+        .mockResolvedValue([makeUser({ id: toUserId('userId1') })])
       userStore.searchIdirLastName = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('b') })])
+        .mockResolvedValue([makeUser({ id: toUserId('userId2') })])
       userStore.searchIdirEmail = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('c') })])
+        .mockResolvedValue([makeUser({ id: toUserId('userId3') })])
       userStore.searchBCeIDDisplayName = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('d') })])
+        .mockResolvedValue([makeUser({ id: toUserId('userId4') })])
       userStore.searchBCeIDEmail = vi
         .fn()
-        .mockResolvedValue([makeUser({ id: toUserId('e') })])
+        .mockResolvedValue([makeUser({ id: toUserId('userId5') })])
     })
 
     it('searches by first name and concatenates BCeID display name results', async () => {
@@ -411,8 +447,7 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.FIRST_NAME.value,
         'Jane',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirFirstName).toHaveBeenCalledWith('Jane')
       expect(userStore.searchBCeIDDisplayName).toHaveBeenCalledWith('Jane')
@@ -426,8 +461,7 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.LAST_NAME.value,
         'Smith',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirLastName).toHaveBeenCalledWith('Smith')
       expect(userStore.searchBCeIDDisplayName).toHaveBeenCalledWith('Smith')
@@ -441,8 +475,7 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.EMAIL.value,
         'jane@example.com',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(userStore.searchIdirEmail).toHaveBeenCalledWith('jane@example.com')
       expect(userStore.searchBCeIDEmail).toHaveBeenCalledWith(
@@ -462,8 +495,7 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.FIRST_NAME.value,
         'Jane',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(notificationMock.error).toHaveBeenCalledWith('User search failed')
       expect(child(wrapper).props('searchResults')).toBeNull()
@@ -476,8 +508,7 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.EMAIL.value,
         'x@x.com',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(child(wrapper).props('loadingSearch')).toBe(false)
     })
@@ -491,10 +522,19 @@ describe('TenantUserContainer', () => {
         IDIR_SEARCH_TYPE.EMAIL.value,
         'x@x.com',
       )
-      await nextTick()
-      await nextTick()
+      await flushPromises()
 
       expect(child(wrapper).props('loadingSearch')).toBe(false)
+    })
+
+    it('shows an error when an invalid search type is provided', async () => {
+      const wrapper = mountComponent()
+
+      await child(wrapper).vm.$emit('search', 'invalid', 'test')
+      await flushPromises()
+
+      expect(notificationMock.error).toHaveBeenCalledWith('User search failed')
+      expect(child(wrapper).props('searchResults')).toBeNull()
     })
   })
 })

--- a/frontend/src/components/route/GroupHeaderContainer.vue
+++ b/frontend/src/components/route/GroupHeaderContainer.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import LoginContainer from '@/components/auth/LoginContainer.vue'
 import GroupHeader from '@/components/group/GroupHeader.vue'
+import LoadingWrapper from '@/components/ui/LoadingWrapper.vue'
 import { useNotification } from '@/composables/useNotification'
 import { type GroupId } from '@/models/group.model'
 import { type TenantId } from '@/models/tenant.model'
@@ -10,7 +12,7 @@ import { useTenantStore } from '@/stores/useTenantStore'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{
+const { groupId, tenantId } = defineProps<{
   groupId: GroupId
   tenantId: TenantId
 }>()
@@ -36,19 +38,23 @@ const enabledServiceCount = computed(
       .length,
 )
 
-const group = computed(() => groupStore.getGroup(props.groupId))
+const group = computed(() => groupStore.getGroup(groupId))
 
-const tenant = computed(() => tenantStore.getTenant(props.tenantId))
+const tenant = computed(() => tenantStore.getTenant(tenantId))
 
 // --- Component Lifecycle -----------------------------------------------------
 
-// Use init() in setup instead of a top-level await, so that loading state is
-// set before first render. Look to Suspense when no longer experimental.
 const initialized = ref(false)
+
+// Use an async function, and do not await since that would block rendering
+// until the fetch resolves. This way setup() can complete synchronously while
+// the fetch is happening, the component mounts immediately, and LoadingWrapper
+// shows a spinner if needed. In the future use <Suspense> once it is no longer
+// experimental.
 const init = async () => {
   const [groupResult, groupServicesResult] = await Promise.allSettled([
-    groupStore.fetchGroup(props.tenantId, props.groupId),
-    groupStore.fetchGroupServices(props.tenantId, props.groupId),
+    groupStore.fetchGroup(tenantId, groupId),
+    groupStore.fetchGroupServices(tenantId, groupId),
   ])
 
   if (groupResult.status === 'rejected') {
@@ -62,18 +68,21 @@ const init = async () => {
   initialized.value = true
 }
 
-init()
+// Sonar will complain (S7785) about top-level await because it doesn't
+// understand that this is a Vue component. Ignore it until <Suspense> is used.
+init() // NOSONAR
 </script>
 
 <template>
-  <template v-if="initialized">
-    <GroupHeader
-      :enabled-roles-count="enabledRolesCount"
-      :enabled-service-count="enabledServiceCount"
-      :group="group!"
-      :tenant="tenant!"
-    />
-
-    <router-view />
-  </template>
+  <LoginContainer>
+    <LoadingWrapper :loading="!initialized" loading-message="Loading group...">
+      <GroupHeader
+        :enabled-roles-count="enabledRolesCount"
+        :enabled-service-count="enabledServiceCount"
+        :group="group!"
+        :tenant="tenant!"
+      />
+      <router-view />
+    </LoadingWrapper>
+  </LoginContainer>
 </template>

--- a/frontend/src/components/route/GroupListContainer.vue
+++ b/frontend/src/components/route/GroupListContainer.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 
+import LoginContainer from '@/components/auth/LoginContainer.vue'
 import GroupCreateDialog from '@/components/group/GroupCreateDialog.vue'
 import GroupList from '@/components/group/GroupList.vue'
 import ButtonPrimary from '@/components/ui/ButtonPrimary.vue'
@@ -19,7 +20,7 @@ import { currentUserHasRole } from '@/utils/permissions'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{
+const { tenantId } = defineProps<{
   tenantId: TenantId
 }>()
 
@@ -50,9 +51,9 @@ const isUserAdmin = computed(() => {
 })
 
 const tenant = computed(() => {
-  const tenant = tenantStore.getTenant(props.tenantId)
+  const tenant = tenantStore.getTenant(tenantId)
   if (!tenant) {
-    throw new Error(`Tenant ${props.tenantId} not found`)
+    throw new Error(`Tenant ${tenantId} not found`)
   }
 
   return tenant
@@ -68,7 +69,7 @@ const dialogClose = () => {
 const dialogOpen = () => (dialogVisible.value = true)
 
 const handleCardClick = (id: Group['id']) => {
-  router.push(`/tenants/${props.tenantId}/groups/${id}/members`)
+  router.push(`/tenants/${tenantId}/groups/${id}/members`)
 }
 
 const handleGroupCreate = async (
@@ -79,7 +80,7 @@ const handleGroupCreate = async (
 
   try {
     group = await groupStore.addGroup(
-      props.tenantId,
+      tenantId,
       groupDetails.name,
       groupDetails.description,
     )
@@ -114,7 +115,7 @@ const handleGroupCreate = async (
   if (addUser) {
     try {
       await groupStore.addGroupUser(
-        props.tenantId,
+        tenantId,
         group.id,
         authStore.authenticatedUser,
       )
@@ -136,47 +137,49 @@ const handleGroupCreate = async (
 </script>
 
 <template>
-  <v-container class="ms-6">
-    <template v-if="groups.length > 0">
-      <h4>Groups</h4>
+  <LoginContainer>
+    <v-container class="ms-6">
+      <template v-if="groups.length > 0">
+        <h4>Groups</h4>
 
-      <ButtonPrimary
-        v-if="isUserAdmin"
-        class="mb-12"
-        text="Create a Group"
-        @click="dialogOpen"
-      />
+        <ButtonPrimary
+          v-if="isUserAdmin"
+          class="mb-12"
+          text="Create a Group"
+          @click="dialogOpen"
+        />
 
-      <GroupList :groups="groups" @select="handleCardClick" />
-    </template>
-    <v-container v-else class="fill-height">
-      <v-row class="center-align justify-center">
-        <v-col class="align-center d-flex flex-column" cols="auto">
-          <h1>No groups yet</h1>
-          <p class="p-large">
-            No groups have been created for this tenant yet.
-            <span v-if="isUserAdmin">
-              Create your first group to get started.
+        <GroupList :groups="groups" @select="handleCardClick" />
+      </template>
+      <v-container v-else class="fill-height">
+        <v-row class="center-align justify-center">
+          <v-col class="align-center d-flex flex-column" cols="auto">
+            <h1>No groups yet</h1>
+            <p class="p-large">
+              No groups have been created for this tenant yet.
+              <span v-if="isUserAdmin">
+                Create your first group to get started.
+              </span>
+            </p>
+
+            <p v-if="isUserAdmin">
+              <ButtonPrimary text="Create a Group" @click="dialogOpen" />
+            </p>
+
+            <span class="mt-12 p-small">
+              Groups help you manage access for multiple users at once and keep
+              role assignments consistent.
             </span>
-          </p>
-
-          <p v-if="isUserAdmin">
-            <ButtonPrimary text="Create a Group" @click="dialogOpen" />
-          </p>
-
-          <span class="mt-12 p-small">
-            Groups help you manage access for multiple users at once and keep
-            role assignments consistent.
-          </span>
-        </v-col>
-      </v-row>
+          </v-col>
+        </v-row>
+      </v-container>
     </v-container>
-  </v-container>
 
-  <GroupCreateDialog
-    v-model="dialogVisible"
-    :is-duplicate-name="isDuplicateName"
-    @clear-duplicate-error="isDuplicateName = false"
-    @submit="handleGroupCreate"
-  />
+    <GroupCreateDialog
+      v-model="dialogVisible"
+      :is-duplicate-name="isDuplicateName"
+      @clear-duplicate-error="isDuplicateName = false"
+      @submit="handleGroupCreate"
+    />
+  </LoginContainer>
 </template>

--- a/frontend/src/components/route/GroupMemberContainer.vue
+++ b/frontend/src/components/route/GroupMemberContainer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import LoginContainer from '@/components/auth/LoginContainer.vue'
 import GroupMemberManagement from '@/components/group/GroupMemberManagement.vue'
 import { useNotification } from '@/composables/useNotification'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
@@ -15,7 +16,7 @@ import { type IdirSearchType, IDIR_SEARCH_TYPE } from '@/utils/constants'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{
+const { groupId, tenantId } = defineProps<{
   groupId: GroupId
   tenantId: TenantId
 }>()
@@ -34,14 +35,14 @@ const searchResults = ref<User[] | null>(null)
 
 // --- Computed Values ---------------------------------------------------------
 
-const group = computed(() => groupStore.getGroup(props.groupId))
-const tenant = computed(() => tenantStore.getTenant(props.tenantId))
+const group = computed(() => groupStore.getGroup(groupId))
+const tenant = computed(() => tenantStore.getTenant(tenantId))
 
 // --- Component Methods -------------------------------------------------------
 
 const handleAddMember = async (user: User) => {
   try {
-    await groupStore.addGroupUser(props.tenantId, props.groupId, user)
+    await groupStore.addGroupUser(tenantId, groupId, user)
     searchResults.value = null
     notification.success(
       'New member successfully added to this group',
@@ -66,7 +67,7 @@ const handleClearSearch = async () => {
 
 const handleDeleteMember = async (groupUserId: GroupUserId) => {
   try {
-    await groupStore.removeGroupUser(props.tenantId, props.groupId, groupUserId)
+    await groupStore.removeGroupUser(tenantId, groupId, groupUserId)
     notification.success(
       'Member successfully removed from this group',
       'Member Removed',
@@ -111,15 +112,17 @@ const handleUserSearch = async (
 </script>
 
 <template>
-  <GroupMemberManagement
-    :group="group!"
-    :loading-search="isLoadingSearch"
-    :search-results="searchResults"
-    :tenant="tenant!"
-    @add="handleAddMember"
-    @cancel="searchResults = null"
-    @clear-search="handleClearSearch"
-    @delete="handleDeleteMember"
-    @search="handleUserSearch"
-  />
+  <LoginContainer>
+    <GroupMemberManagement
+      :group="group!"
+      :loading-search="isLoadingSearch"
+      :search-results="searchResults"
+      :tenant="tenant!"
+      @add="handleAddMember"
+      @cancel="searchResults = null"
+      @clear-search="handleClearSearch"
+      @delete="handleDeleteMember"
+      @search="handleUserSearch"
+    />
+  </LoginContainer>
 </template>

--- a/frontend/src/components/route/TenantHeaderContainer.vue
+++ b/frontend/src/components/route/TenantHeaderContainer.vue
@@ -4,6 +4,7 @@ import { useRoute } from 'vue-router'
 
 import LoginContainer from '@/components/auth/LoginContainer.vue'
 import TenantHeader from '@/components/tenant/TenantHeader.vue'
+import LoadingWrapper from '@/components/ui/LoadingWrapper.vue'
 import { useNotification } from '@/composables/useNotification'
 import { type TenantId } from '@/models/tenant.model'
 import { useGroupStore } from '@/stores/useGroupStore'
@@ -11,30 +12,34 @@ import { useTenantStore } from '@/stores/useTenantStore'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{ tenantId: TenantId }>()
+const { tenantId } = defineProps<{ tenantId: TenantId }>()
 
 // --- Store and Composable Setup ----------------------------------------------
 
 const groupStore = useGroupStore()
 const notification = useNotification()
-const tenantStore = useTenantStore()
 const route = useRoute()
+const tenantStore = useTenantStore()
 
 // --- Computed Values ---------------------------------------------------------
 
 const groups = computed(() => groupStore.groups)
 
-const tenant = computed(() => tenantStore.getTenant(props.tenantId))
+const tenant = computed(() => tenantStore.getTenant(tenantId))
 
 // --- Component Lifecycle ---------------------------------------------------------
 
-// Use init() in setup instead of a top-level await, so that loading state is
-// set before first render. Look to Suspense when no longer experimental.
 const initialized = ref(false)
+
+// Use an async function, and do not await since that would block rendering
+// until the fetch resolves. This way setup() can complete synchronously while
+// the fetch is happening, the component mounts immediately, and LoadingWrapper
+// shows a spinner if needed. In the future use <Suspense> once it is no longer
+// experimental.
 const init = async () => {
   const [groupsResult, tenantResult] = await Promise.allSettled([
-    groupStore.fetchGroups(props.tenantId),
-    tenantStore.fetchTenant(props.tenantId),
+    groupStore.fetchGroups(tenantId),
+    tenantStore.fetchTenant(tenantId),
   ])
 
   if (groupsResult.status === 'rejected') {
@@ -48,18 +53,20 @@ const init = async () => {
   initialized.value = true
 }
 
-init()
+// Sonar will complain (S7785) about top-level await because it doesn't
+// understand that this is a Vue component. Ignore it until <Suspense> is used.
+init() // NOSONAR
 </script>
 
 <template>
-  <template v-if="initialized">
-    <LoginContainer>
+  <LoginContainer>
+    <LoadingWrapper :loading="!initialized" loading-message="Loading tenant...">
       <TenantHeader
         v-if="!route.params.groupId"
         :groups="groups!"
         :tenant="tenant!"
       />
       <router-view />
-    </LoginContainer>
-  </template>
+    </LoadingWrapper>
+  </LoginContainer>
 </template>

--- a/frontend/src/components/route/TenantListContainer.vue
+++ b/frontend/src/components/route/TenantListContainer.vue
@@ -6,6 +6,7 @@ import LoginContainer from '@/components/auth/LoginContainer.vue'
 import TenantList from '@/components/tenant/TenantList.vue'
 import TenantRequestDialog from '@/components/tenantrequest/TenantRequestDialog.vue'
 import ButtonPrimary from '@/components/ui/ButtonPrimary.vue'
+import LoadingWrapper from '@/components/ui/LoadingWrapper.vue'
 import { useNotification } from '@/composables/useNotification'
 import { DomainError } from '@/errors/domain/DomainError'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
@@ -78,8 +79,13 @@ const handleTenantSubmit = async (
 
 // --- Component Lifecycle -----------------------------------------------------
 
-// Use init() in setup instead of a top-level await, so that loading state is
-// set before first render. Look to Suspense when no longer experimental.
+const initialized = ref(false)
+
+// Use an async function, and do not await since that would block rendering
+// until the fetch resolves. This way setup() can complete synchronously while
+// the fetch is happening, the component mounts immediately, and LoadingWrapper
+// shows a spinner if needed. In the future use <Suspense> once it is no longer
+// experimental.
 const init = async () => {
   try {
     await tenantStore.fetchTenants(
@@ -88,41 +94,50 @@ const init = async () => {
   } catch {
     notification.error('Failed to load tenants')
   }
+
+  initialized.value = true
 }
 
-init()
+// Sonar will complain (S7785) about top-level await because it doesn't
+// understand that this is a Vue component. Ignore it until <Suspense> is used.
+init() // NOSONAR
 </script>
 
 <template>
   <LoginContainer>
-    <v-container v-if="tenants.length === 0" class="fill-height">
-      <v-row class="center-align justify-center">
-        <v-col class="align-center d-flex flex-column" cols="auto">
-          <h1>No tenants yet</h1>
-          <p class="p-large">You don't currently have access to a tenant.</p>
+    <LoadingWrapper
+      :loading="!initialized"
+      loading-message="Loading tenants..."
+    >
+      <v-container v-if="tenants.length === 0" class="fill-height">
+        <v-row class="center-align justify-center">
+          <v-col class="align-center d-flex flex-column" cols="auto">
+            <h1>No tenants yet</h1>
+            <p class="p-large">You don't currently have access to a tenant.</p>
 
-          <p>
+            <p>
+              <ButtonPrimary text="Request a Tenant" @click="dialogOpen" />
+            </p>
+
+            <span class="mt-12 p-small">
+              If your team already has a tenant, ask a tenant owner or user
+              admin to add you.
+            </span>
+            <span class="p-small">
+              <em>Requests are reviewed by the CSTAR team.</em>
+            </span>
+          </v-col>
+        </v-row>
+      </v-container>
+      <template v-else>
+        <v-row class="mb-8 mt-12">
+          <v-col cols="12">
             <ButtonPrimary text="Request a Tenant" @click="dialogOpen" />
-          </p>
-
-          <span class="mt-12 p-small">
-            If your team already has a tenant, ask a tenant owner or user admin
-            to add you.
-          </span>
-          <span class="p-small">
-            <em>Requests are reviewed by the CSTAR team.</em>
-          </span>
-        </v-col>
-      </v-row>
-    </v-container>
-    <template v-else>
-      <v-row class="mb-8 mt-12">
-        <v-col cols="12">
-          <ButtonPrimary text="Request a Tenant" @click="dialogOpen" />
-        </v-col>
-      </v-row>
-      <TenantList :tenants="tenants" @select="handleCardClick" />
-    </template>
+          </v-col>
+        </v-row>
+        <TenantList :tenants="tenants" @select="handleCardClick" />
+      </template>
+    </LoadingWrapper>
   </LoginContainer>
 
   <TenantRequestDialog

--- a/frontend/src/components/route/TenantServiceContainer.vue
+++ b/frontend/src/components/route/TenantServiceContainer.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import LoginContainer from '@/components/auth/LoginContainer.vue'
 import ServiceManagement from '@/components/service/ServiceManagement.vue'
+import LoadingWrapper from '@/components/ui/LoadingWrapper.vue'
 import { useNotification } from '@/composables/useNotification'
 import { type ServiceId } from '@/models/service.model'
 import { type TenantId } from '@/models/tenant.model'
@@ -10,7 +12,7 @@ import { useTenantStore } from '@/stores/useTenantStore'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{
+const { tenantId } = defineProps<{
   tenantId: TenantId
 }>()
 
@@ -24,7 +26,7 @@ const tenantStore = useTenantStore()
 
 const handleAddService = async (serviceId: ServiceId) => {
   try {
-    await serviceStore.addServiceToTenant(props.tenantId, serviceId)
+    await serviceStore.addServiceToTenant(tenantId, serviceId)
 
     // Find the added service and add it to tenantServices.
     const addedService = services.value.find(
@@ -46,35 +48,39 @@ const handleAddService = async (serviceId: ServiceId) => {
 // --- Computed Values ---------------------------------------------------------
 
 const services = computed(() =>
-  [...serviceStore.services].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
+  [...serviceStore.services].sort((service1, service2) =>
+    service1.displayName.localeCompare(service2.displayName),
   ),
 )
 
 const tenant = computed(() => {
-  const tenant = tenantStore.getTenant(props.tenantId)
+  const tenant = tenantStore.getTenant(tenantId)
   if (!tenant) {
-    throw new Error(`Tenant ${props.tenantId} not found`)
+    throw new Error(`Tenant ${tenantId} not found`)
   }
 
   return tenant
 })
 
 const tenantServices = computed(() =>
-  [...serviceStore.tenantServices].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName),
+  [...serviceStore.tenantServices].sort((tenantService1, tenantService2) =>
+    tenantService1.displayName.localeCompare(tenantService2.displayName),
   ),
 )
 
 // --- Component Lifecycle -----------------------------------------------------
 
-// Use init() in setup instead of a top-level await, so that loading state is
-// set before first render. Look to Suspense when no longer experimental.
 const initialized = ref(false)
+
+// Use an async function, and do not await since that would block rendering
+// until the fetch resolves. This way setup() can complete synchronously while
+// the fetch is happening, the component mounts immediately, and LoadingWrapper
+// shows a spinner if needed. In the future use <Suspense> once it is no longer
+// experimental.
 const init = async () => {
   const [servicesResult, tenantServicesResult] = await Promise.allSettled([
     serviceStore.fetchServices(),
-    serviceStore.fetchTenantServices(props.tenantId),
+    serviceStore.fetchTenantServices(tenantId),
   ])
 
   if (servicesResult.status === 'rejected') {
@@ -88,16 +94,23 @@ const init = async () => {
   initialized.value = true
 }
 
-init()
+// Sonar will complain (S7785) about top-level await because it doesn't
+// understand that this is a Vue component. Ignore it until <Suspense> is used.
+init() // NOSONAR
 </script>
 
 <template>
-  <template v-if="initialized">
-    <ServiceManagement
-      :services="services"
-      :tenant="tenant!"
-      :tenant-services="tenantServices"
-      @add-service="handleAddService"
-    />
-  </template>
+  <LoginContainer>
+    <LoadingWrapper
+      :loading="!initialized"
+      loading-message="Loading connected services..."
+    >
+      <ServiceManagement
+        :services="services"
+        :tenant="tenant!"
+        :tenant-services="tenantServices"
+        @add-service="handleAddService"
+      />
+    </LoadingWrapper>
+  </LoginContainer>
 </template>

--- a/frontend/src/components/route/TenantUserContainer.vue
+++ b/frontend/src/components/route/TenantUserContainer.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 
+import LoginContainer from '@/components/auth/LoginContainer.vue'
 import TenantUserManagement from '@/components/tenant/TenantUserManagement.vue'
+import LoadingWrapper from '@/components/ui/LoadingWrapper.vue'
 import { useNotification } from '@/composables/useNotification'
 import { DuplicateEntityError } from '@/errors/domain/DuplicateEntityError'
 import { Group } from '@/models/group.model'
@@ -16,7 +18,7 @@ import { type IdirSearchType, IDIR_SEARCH_TYPE } from '@/utils/constants'
 
 // --- Component Interface -----------------------------------------------------
 
-const props = defineProps<{
+const { tenantId } = defineProps<{
   tenantId: TenantId
 }>()
 
@@ -38,9 +40,9 @@ const searchResults = ref<User[] | null>(null)
 const roles = computed(() => roleStore.roles)
 
 const tenant = computed(() => {
-  const tenant = tenantStore.getTenant(props.tenantId)
+  const tenant = tenantStore.getTenant(tenantId)
   if (!tenant) {
-    throw new Error(`Tenant ${props.tenantId} not found`)
+    throw new Error(`Tenant ${tenantId} not found`)
   }
 
   return tenant
@@ -51,7 +53,7 @@ const tenant = computed(() => {
 const handleAddUser = async (user: User, groups: Group[]) => {
   let addToGroups = true
   try {
-    await tenantStore.addTenantUser(props.tenantId, user)
+    await tenantStore.addTenantUser(tenantId, user)
     searchResults.value = null
     notification.success(
       'New user successfully added to this tenant',
@@ -76,13 +78,13 @@ const handleAddUser = async (user: User, groups: Group[]) => {
 
   try {
     for (const group of groups) {
-      await groupStore.addGroupUser(props.tenantId, group.id, user)
+      await groupStore.addGroupUser(tenantId, group.id, user)
     }
 
     // Only show alert if user was added to at least one group.
     if (groups.length > 0) {
       notification.success(
-        'New user succesfully added to groups',
+        'New user successfully added to groups',
         'User Added to Groups',
       )
     }
@@ -97,7 +99,7 @@ const handleClearSearch = async () => {
 
 const handleRemoveRole = async (userId: UserId, roleId: RoleId) => {
   try {
-    await tenantStore.removeTenantUserRole(props.tenantId, userId, roleId)
+    await tenantStore.removeTenantUserRole(tenantId, userId, roleId)
     notification.success(
       'The role was successfully removed from the user',
       'Role Removed',
@@ -113,7 +115,7 @@ const handleRemoveUser = async (userId: UserId) => {
       throw new Error('No user selected')
     }
 
-    await tenantStore.removeTenantUser(props.tenantId, userId)
+    await tenantStore.removeTenantUser(tenantId, userId)
     notification.success('The user was successfully removed', 'User Removed')
   } catch {
     notification.error('Failed to remove user')
@@ -155,30 +157,46 @@ const handleUserSearch = async (
 
 // --- Component Lifecycle -----------------------------------------------------
 
-// Use init() in setup instead of a top-level await, so that loading state is
-// set before first render. Look to Suspense when no longer experimental.
+const initialized = ref(false)
+
+// Use an async function, and do not await since that would block rendering
+// until the fetch resolves. This way setup() can complete synchronously while
+// the fetch is happening, the component mounts immediately, and LoadingWrapper
+// shows a spinner if needed. In the future use <Suspense> once it is no longer
+// experimental.
 const init = async () => {
   try {
     await roleStore.fetchRoles()
   } catch {
     notification.error('Failed to load roles')
   }
+
+  initialized.value = true
 }
 
-init()
+// Sonar will complain (S7785) about top-level await because it doesn't
+// understand that this is a Vue component. Ignore it until <Suspense> is used.
+init() // NOSONAR
 </script>
 
 <template>
-  <TenantUserManagement
-    :loading-search="isLoadingSearch"
-    :possible-roles="roles"
-    :search-results="searchResults"
-    :tenant="tenant"
-    @add="handleAddUser"
-    @cancel="searchResults = null"
-    @clear-search="handleClearSearch"
-    @remove-role="handleRemoveRole"
-    @remove-user="handleRemoveUser"
-    @search="handleUserSearch"
-  />
+  <LoginContainer>
+    <LoadingWrapper
+      :loading="!initialized"
+      loading-message="Loading tenant users..."
+    >
+      <TenantUserManagement
+        :loading-search="isLoadingSearch"
+        :possible-roles="roles"
+        :search-results="searchResults"
+        :tenant="tenant"
+        @add="handleAddUser"
+        @cancel="searchResults = null"
+        @clear-search="handleClearSearch"
+        @remove-role="handleRemoveRole"
+        @remove-user="handleRemoveUser"
+        @search="handleUserSearch"
+      />
+    </LoadingWrapper>
+  </LoginContainer>
 </template>

--- a/frontend/src/components/ui/LoadingWrapper.vue
+++ b/frontend/src/components/ui/LoadingWrapper.vue
@@ -53,13 +53,12 @@ onBeforeUnmount(() => {
   <v-container class="ma-0 pa-0">
     <v-row v-if="loading && showSpinner" class="align-center justify-center">
       <v-col class="text-center" cols="auto">
-        <v-progress-circular data-testid="spinner" indeterminate />
+        <v-progress-circular class="mt-8" data-testid="spinner" indeterminate />
         <div v-if="loadingMessage" class="mt-2" data-testid="message">
           {{ loadingMessage }}
         </div>
       </v-col>
     </v-row>
-
     <template v-else-if="!loading">
       <div data-testid="content">
         <slot />

--- a/frontend/src/services/authenticated.axios.ts
+++ b/frontend/src/services/authenticated.axios.ts
@@ -16,6 +16,8 @@ export const authenticatedAxios = (timeout = 60000): AxiosInstance => {
   const instance = axios.create({ timeout })
 
   instance.interceptors.request.use(async (cfg) => {
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+
     cfg.baseURL = config.api.baseUrl
 
     const authStore = useAuthStore()


### PR DESCRIPTION
<!--
Give a general description of the changes in the Title above

Title format: <type>(<scope>): CCP-<jira id> <short description>
For example:  fix(ui): CCP-1234 make login button blue

Conventional Commit types: build, chore, ci, docs, feat, fix, perf, refactor,
  revert, style, test
-->

# Description

<!--
Give a detailed summary of the change.

Tip: the Jira ticket description, including "Acceptance Criteria", can be
written so that it can be pasted into this description.
-->

There are many pages where content “flashes” one thing (like an empty state) and then immediately displays content. This should be fixed so that content isn’t displayed until data exists. Examples include the tenant card list, but the user searches are out of scope and will be done in CCP-5193.

### Acceptance Criteria
- Flashy pages are identified and fixed

## Type of change

`fix`: a bug fix for the product
<!-- Uncomment the one type that applies - it will be also used in the title.
`build`: changes to the build system or dependencies
`chore`: miscellaneous changes that don't fit another type
`ci`: changes to CI/CD configuration and scripts
`docs`: documentation only changes
`feat`: a new feature for the product
`perf`: a code change that improves performance
`refactor`: a code change that neither fixes a bug nor adds a feature
`revert`: reverts a previous commit
`style`: changes that do not affect the meaning of the code
`test`: adding missing tests or correcting existing tests
-->

## Checklist

<!--
Check each item with an `x` to confirm that the step is complete. This list is
meant to be a helpful reminder of what is needed for a complete pull request.
-->

- [x] I have performed a thorough self-review of the changes in this PR
- [x] The changes are self-explanatory or have comments where needed
- [x] I have checked that documentation is still accurate after these changes
- [x] My changes are covered by the existing tests or tests have been added

<!--
## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://cstar-640.apps.gold.devops.gov.bc.ca)
- [Backend](https://cstar-640.apps.gold.devops.gov.bc.ca/api/v1)
- [OpenAPI](https://cstar-640.apps.gold.devops.gov.bc.ca/api/v1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/merge.yml)