### PR TITLE
feat(tenant name length): changed tenant name and tenant request name from 30 chars to 255 per …

### DIFF
--- a/backend/src/common/tms.validator.ts
+++ b/backend/src/common/tms.validator.ts
@@ -10,7 +10,7 @@ export default {
     body: Joi.object({
       name: Joi.string()
         .min(1)
-        .max(30)
+        .max(255)
         .pattern(/^\S.*\S$/)
         .required(),
       ministryName: Joi.string().min(1).max(100).required(),
@@ -183,7 +183,7 @@ export default {
     body: Joi.object({
       name: Joi.string()
         .min(1)
-        .max(30)
+        .max(255)
         .pattern(/^\S.*\S$/)
         .optional(),
       ministryName: Joi.string().min(1).max(100).optional(),
@@ -195,7 +195,7 @@ export default {
     body: Joi.object({
       name: Joi.string()
         .min(1)
-        .max(30)
+        .max(255)
         .pattern(/^\S.*\S$/)
         .required(),
       ministryName: Joi.string().min(1).max(100).required(),
@@ -224,9 +224,8 @@ export default {
         then: Joi.string().required(),
         otherwise: Joi.string().optional(),
       }),
-      tenantName: Joi.string().when('status', {
+      tenantName: Joi.string().min(1).max(255).when('status', {
         is: 'APPROVED',
-        //code quality complains about this but it matches above (it doesn't like then in an object)
         then: Joi.string().optional(),
         otherwise: Joi.forbidden(),
       }),

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -60,7 +60,7 @@ paths:
                 name:
                   type: string
                   minLength: 1
-                  maxLength: 30
+                  maxLength: 255
                   pattern: '^\S.*\S$'
                   description: |
                     Name must be 1-30 characters, cannot start or end with whitespace.
@@ -1126,7 +1126,7 @@ paths:
                 name:
                   type: string
                   minLength: 1
-                  maxLength: 30
+                  maxLength: 255
                   example: 'Updated Roads Initiative'
                 ministryName:
                   type: string
@@ -1254,7 +1254,7 @@ paths:
                 name:
                   type: string
                   minLength: 1
-                  maxLength: 30
+                  maxLength: 255
                   example: 'Roads Initiative'
                 ministryName:
                   type: string
@@ -1464,6 +1464,8 @@ paths:
                   example: 'APPROVED'
                 tenantName:
                   type: string
+                  minLength: 1
+                  maxLength: 255
                   description: If status is approved, tenantName can be provided to change the tenant name on approval, this allows for approval when a collision of names would otherwise occur
                   example: 'Tenant name NEW'
                 rejectionReason:
@@ -3831,7 +3833,7 @@ components:
         name:
           type: string
           minLength: 1
-          maxLength: 30
+          maxLength: 255
           example: 'Roads Initiative'
         ministryName:
           type: string

--- a/backend/src/entities/Tenant.ts
+++ b/backend/src/entities/Tenant.ts
@@ -15,7 +15,7 @@ export class Tenant {
   @PrimaryGeneratedColumn('uuid', { name: 'id' })
   id!: string
 
-  @Column({ length: 30, name: 'name' })
+  @Column({ length: 255, name: 'name' })
   name!: string
 
   @Column({ length: 100, name: 'ministry_name' })

--- a/backend/src/entities/TenantRequest.ts
+++ b/backend/src/entities/TenantRequest.ts
@@ -16,7 +16,7 @@ export class TenantRequest {
   @PrimaryGeneratedColumn('uuid', { name: 'id' })
   id!: string
 
-  @Column({ length: 30, name: 'name' })
+  @Column({ length: 255, name: 'name' })
   name!: string
 
   @Column({ length: 100, name: 'ministry_name' })

--- a/backend/src/migrations/1786406400000-widen-tenant-name.ts
+++ b/backend/src/migrations/1786406400000-widen-tenant-name.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+const TABLES = ['Tenant', 'TenantRequest']
+
+export class WidenTenantName1786406400000 implements MigrationInterface {
+  name = 'WidenTenantName1786406400000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    for (const table of TABLES) {
+      await queryRunner.query(
+        `DO $$
+         BEGIN
+           IF EXISTS (
+             SELECT 1 FROM information_schema.columns
+             WHERE table_schema = 'tms'
+               AND table_name = '${table}'
+               AND column_name = 'name'
+               AND character_maximum_length <> 255
+           ) THEN
+             ALTER TABLE "tms"."${table}"
+               ALTER COLUMN "name" TYPE character varying(255);
+           END IF;
+         END $$`,
+      )
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    for (const table of TABLES) {
+      await queryRunner.query(
+        `ALTER TABLE "tms"."${table}"
+           ALTER COLUMN "name" TYPE character varying(30)`,
+      )
+    }
+  }
+}

--- a/backend/src/tests/validators/tenant-name-length.validator.test.ts
+++ b/backend/src/tests/validators/tenant-name-length.validator.test.ts
@@ -1,0 +1,127 @@
+import request from 'supertest'
+import express, { type ErrorRequestHandler } from 'express'
+import { validate } from 'express-validation'
+import validator from '../../common/tms.validator'
+
+function createApp(
+  method: 'post' | 'put' | 'patch',
+  path: string,
+  schema: Parameters<typeof validate>[0],
+) {
+  const app = express()
+  app.use(express.json())
+  app[method](path, validate(schema, {}, {}), (_req, res) =>
+    res.status(200).json({ ok: true }),
+  )
+  const errorHandler: ErrorRequestHandler = (err, _req, res, next) => {
+    if (
+      err &&
+      typeof err === 'object' &&
+      'name' in err &&
+      (err as { name: string }).name === 'ValidationError'
+    ) {
+      return res.status((err as { statusCode: number }).statusCode).json(err)
+    }
+    next(err)
+  }
+  app.use(errorHandler)
+  return app
+}
+
+const nameOfLength = (length: number) => 'a'.repeat(length)
+
+const UUID = '123e4567-e89b-12d3-a456-426614174000'
+const MINISTRY = 'Ministry of Natural Resources'
+const USER = {
+  firstName: 'Shankar',
+  lastName: 'Sethuraman',
+  displayName: 'Sethuraman, Shankar JEG:EX',
+  userName: 'SSETHURA',
+  ssoUserId: 'F45AFBBD68C44D6F956BA3A1D91878AD',
+  email: 'shankar.sethuraman@gov.bc.ca',
+}
+
+const TENANT_USER = { ...USER, idpType: 'idir' }
+
+function rejectedField(body: unknown): string {
+  return JSON.stringify(body)
+}
+
+describe('tenant name length', () => {
+  describe('createTenant', () => {
+    const app = createApp('post', '/', validator.createTenant)
+
+    const send = (name: string) =>
+      request(app)
+        .post('/')
+        .send({ name, ministryName: MINISTRY, user: TENANT_USER })
+
+    it('accepts a name of 255 characters', async () => {
+      expect((await send(nameOfLength(255))).status).toBe(200)
+    })
+
+    it('rejects a name of 256 characters', async () => {
+      const response = await send(nameOfLength(256))
+
+      expect(response.status).toBe(400)
+      expect(rejectedField(response.body)).toContain('name')
+    })
+  })
+
+  describe('createTenantRequest', () => {
+    const app = createApp('post', '/', validator.createTenantRequest)
+
+    const send = (name: string) =>
+      request(app).post('/').send({ name, ministryName: MINISTRY, user: USER })
+
+    it('accepts a name of 255 characters', async () => {
+      expect((await send(nameOfLength(255))).status).toBe(200)
+    })
+
+    it('rejects a name of 256 characters', async () => {
+      const response = await send(nameOfLength(256))
+
+      expect(response.status).toBe(400)
+      expect(rejectedField(response.body)).toContain('name')
+    })
+  })
+
+  describe('updateTenant', () => {
+    const app = createApp('put', '/:tenantId', validator.updateTenant)
+
+    const send = (name: string) => request(app).put(`/${UUID}`).send({ name })
+
+    it('accepts a name of 255 characters', async () => {
+      expect((await send(nameOfLength(255))).status).toBe(200)
+    })
+
+    it('rejects a name of 256 characters', async () => {
+      const response = await send(nameOfLength(256))
+
+      expect(response.status).toBe(400)
+      expect(rejectedField(response.body)).toContain('name')
+    })
+  })
+
+  describe('updateTenantRequestStatus tenantName', () => {
+    const app = createApp(
+      'patch',
+      '/:requestId',
+      validator.updateTenantRequestStatus,
+    )
+
+    const send = (tenantName: string) =>
+      request(app).patch(`/${UUID}`).send({ status: 'APPROVED', tenantName })
+
+    it('accepts a renamed tenant of 255 characters on approval', async () => {
+      expect((await send(nameOfLength(255))).status).toBe(200)
+    })
+
+    it('rejects a renamed tenant of 256 characters on approval', async () => {
+      const response = await send(nameOfLength(256))
+
+      expect(response.status).toBe(400)
+      expect(rejectedField(response.body)).toContain('tenantName')
+    })
+  })
+})


### PR DESCRIPTION
Description

Per EA's request Tenant Name and Tenant Request Name lengths are now 255 chars from 30 chars previously. 

Changes:

1. Entities Tenant and Tenant Requests now use name fields as 255 chars
2. Validator updated to allow these names to have up to 255 chars
3. OAS updated to reflect these changs
4. New migration to migrate the 2 entities above in 1 migration file
5. New unit tests added 

Type of change

`feat`: a new feature for the product
`test`: adding missing tests or correcting existing tests

Checklist

- [x] I have performed a thorough self-review of the changes in this PR
- [x] The changes are self-explanatory or have comments where needed
- [x] I have checked that documentation is still accurate after these changes
- [x] My changes are covered by the existing tests or tests have been added

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://cstar-644.apps.gold.devops.gov.bc.ca)
- [Backend](https://cstar-644.apps.gold.devops.gov.bc.ca/api/v1)
- [OpenAPI](https://cstar-644.apps.gold.devops.gov.bc.ca/api/v1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/merge.yml)