### PR TITLE
feat: notifications - new tenant requests are now notified to a specific mailbox as set in env vars

### DIFF
--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -81,7 +81,7 @@ jobs:
     name: Stack
     environment:
       name: ${{ inputs.environment || 'dev' }}
-      url: 'https://${{ steps.vars.outputs.release }}.${{ steps.vars.outputs.domain }}'
+      url: "https://${{ steps.vars.outputs.release }}.${{ steps.vars.outputs.domain }}"
     runs-on: ubuntu-24.04
     outputs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -197,12 +197,12 @@ jobs:
               --set-string backend.adminNotificationEmail=${{ vars.ADMIN_NOTIFICATION_EMAIL }} \
               --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \ 
               --set-string global.repository=${{ github.repository }} \
-              --set-string global.tag="${{ steps.vars.outputs.tag }}" \
-              --set-string global.config.databaseUser="${{ inputs.db_user }}" \
-              --set-string global.databaseAlias="${{ steps.deploy_crunchy.outputs.release }}-crunchy" \
-              --set-string global.loginProxy.clientId="${{ vars.LOGIN_PROXY_CLIENT_ID }}" \
-              --set-string global.loginProxy.hostName="${{ vars.LOGIN_PROXY_HOST_NAME }}" \
-              --set-string global.env.logLevel="${{ vars.LOG_LEVEL }}" \
+              --set-string global.tag=${{ steps.vars.outputs.tag }} \
+              --set-string global.config.databaseUser=${{ inputs.db_user }} \
+              --set-string global.databaseAlias=${{ steps.deploy_crunchy.outputs.release }}-crunchy \
+              --set-string global.loginProxy.clientId=${{ vars.LOGIN_PROXY_CLIENT_ID }} \
+              --set-string global.loginProxy.hostName=${{ vars.LOGIN_PROXY_HOST_NAME }} \
+              --set-string global.env.logLevel=${{ vars.LOG_LEVEL }} \
               ${{ inputs.params }} \
               --install --wait ${{ inputs.atomic && '--atomic' || '' }} ${{ steps.vars.outputs.release }} \
               --timeout ${{ inputs.timeout-minutes }}m \

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -195,8 +195,8 @@ jobs:
               --set-string backend.chesTokenUrl=${{ vars.CHES_TOKEN_URL }} \
               --set-string backend.chesApiUrl=${{ vars.CHES_API_URL }} \
               --set-string backend.adminNotificationEmail=${{ vars.ADMIN_NOTIFICATION_EMAIL }} \
-              --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \              
-              --set-string global.repository=${{ github.repository }} \
+              --set-string backend.appBaseUrl="${{ vars.APP_BASE_URL }}" \ 
+              --set-string global.repository="${{ github.repository }}" \
               --set-string global.tag="${{ steps.vars.outputs.tag }}" \
               --set-string global.config.databaseUser="${{ inputs.db_user }}" \
               --set-string global.databaseAlias="${{ steps.deploy_crunchy.outputs.release }}-crunchy" \

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -195,8 +195,8 @@ jobs:
               --set-string backend.chesTokenUrl=${{ vars.CHES_TOKEN_URL }} \
               --set-string backend.chesApiUrl=${{ vars.CHES_API_URL }} \
               --set-string backend.adminNotificationEmail=${{ vars.ADMIN_NOTIFICATION_EMAIL }} \
-              --set-string backend.appBaseUrl="${{ vars.APP_BASE_URL }}" \ 
-              --set-string global.repository="${{ github.repository }}" \
+              --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \ 
+              --set-string global.repository=${{ github.repository }} \
               --set-string global.tag="${{ steps.vars.outputs.tag }}" \
               --set-string global.config.databaseUser="${{ inputs.db_user }}" \
               --set-string global.databaseAlias="${{ steps.deploy_crunchy.outputs.release }}-crunchy" \

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -81,7 +81,7 @@ jobs:
     name: Stack
     environment:
       name: ${{ inputs.environment || 'dev' }}
-      url: "https://${{ steps.vars.outputs.release }}.${{ steps.vars.outputs.domain }}"
+      url: 'https://${{ steps.vars.outputs.release }}.${{ steps.vars.outputs.domain }}'
     runs-on: ubuntu-24.04
     outputs:
       tag: ${{ inputs.tag || steps.pr.outputs.pr }}
@@ -124,7 +124,7 @@ jobs:
 
           # Version, to support helm packaging for non-pr based releases (workflow_dispatch). default to 1.0.0+github run number
           version=1.0.0+${{ github.run_number }}
-          
+
           # Extract domain name for github host url
           server=${{ vars.OC_SERVER }}
           domain=$(echo "$server" | sed -E 's#https?://##; s#:[0-9]+##; s#^api\.#apps.#')
@@ -187,9 +187,15 @@ jobs:
               --set-string backend.tmsAudience=${{ vars.tms_audience }} \
               --set-string backend.bcgovSsoApiClientId=${{ secrets.bcgov_sso_api_client_id }} \
               --set-string backend.bcgovSsoApiClientSecret=${{ secrets.bcgov_sso_api_client_secret }} \
+              --set-string backend.chesClientId=${{ secrets.CHES_CLIENT_ID }} \
+              --set-string backend.chesClientSecret=${{ secrets.CHES_CLIENT_SECRET }} \
               --set-string backend.bcgovSsoApiUrl=${{ vars.BCGOV_SSO_API_URL }} \
               --set-string backend.bcgovSsoApiUrlBceid=${{ vars.BCGOV_SSO_API_URL_BCEID }} \
               --set-string backend.bcgovTokenUrl=${{ vars.BCGOV_TOKEN_URL }} \
+              --set-string backend.chesTokenUrl=${{ vars.CHES_TOKEN_URL }} \
+              --set-string backend.chesApiUrl=${{ vars.CHES_API_URL }} \
+              --set-string backend.adminNotificationEmail=${{ vars.ADMIN_NOTIFICATION_EMAIL }} \
+              --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \              
               --set-string global.repository=${{ github.repository }} \
               --set-string global.tag="${{ steps.vars.outputs.tag }}" \
               --set-string global.config.databaseUser="${{ inputs.db_user }}" \

--- a/.github/workflows/.deployer.yml
+++ b/.github/workflows/.deployer.yml
@@ -195,7 +195,7 @@ jobs:
               --set-string backend.chesTokenUrl=${{ vars.CHES_TOKEN_URL }} \
               --set-string backend.chesApiUrl=${{ vars.CHES_API_URL }} \
               --set-string backend.adminNotificationEmail=${{ vars.ADMIN_NOTIFICATION_EMAIL }} \
-              --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \ 
+              --set-string backend.appBaseUrl=${{ vars.APP_BASE_URL }} \
               --set-string global.repository=${{ github.repository }} \
               --set-string global.tag=${{ steps.vars.outputs.tag }} \
               --set-string global.config.databaseUser=${{ inputs.db_user }} \

--- a/backend/src/services/ches.service.ts
+++ b/backend/src/services/ches.service.ts
@@ -1,0 +1,100 @@
+import axios from 'axios'
+import { URLSearchParams } from 'url'
+import { getErrorMessage } from '../common/error.handler'
+import { config } from './config.service'
+
+const REQUEST_TIMEOUT_MS = 5000
+const TOKEN_EXPIRY_BUFFER_MS = 30000
+
+export const NOTIFICATION_FROM_EMAIL = 'CSTAR@gov.bc.ca'
+
+export interface ChesEmail {
+  to: string[]
+  subject: string
+  body: string
+}
+
+export interface ChesSendResult {
+  msgId?: string
+  txId?: string
+}
+
+export class ChesService {
+  private cachedToken: string | null = null
+  private cachedTokenExpiresAt = 0
+
+  public isConfigured(): boolean {
+    return Boolean(
+      config.ches?.clientId &&
+      config.ches?.clientSecret &&
+      config.ches?.tokenUrl &&
+      config.ches?.apiUrl,
+    )
+  }
+
+  private async getToken() {
+    if (this.cachedToken && Date.now() < this.cachedTokenExpiresAt) {
+      return this.cachedToken
+    }
+
+    try {
+      const response = await axios.post(
+        config.ches.tokenUrl as string,
+        new URLSearchParams({
+          client_id: config.ches.clientId as string,
+          client_secret: config.ches.clientSecret as string,
+          grant_type: 'client_credentials',
+        }),
+        {
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          timeout: REQUEST_TIMEOUT_MS,
+        },
+      )
+
+      const token: string = response.data.access_token
+      const expiresInMs: number = (response.data.expires_in || 0) * 1000
+
+      this.cachedToken = token
+      this.cachedTokenExpiresAt =
+        Date.now() + Math.max(expiresInMs - TOKEN_EXPIRY_BUFFER_MS, 0)
+
+      return token
+    } catch (error: unknown) {
+      this.cachedToken = null
+      this.cachedTokenExpiresAt = 0
+      throw new Error(
+        'Failed to obtain CHES access token: ' + getErrorMessage(error),
+      )
+    }
+  }
+
+  public async sendEmail(email: ChesEmail) {
+    const token: string = await this.getToken()
+
+    const response = await axios.post(
+      config.ches.apiUrl as string,
+      {
+        bodyType: 'text',
+        body: email.body,
+        from: NOTIFICATION_FROM_EMAIL,
+        subject: email.subject,
+        to: email.to,
+        encoding: 'utf-8',
+        priority: 'normal',
+      },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        timeout: REQUEST_TIMEOUT_MS,
+      },
+    )
+
+    const result: ChesSendResult = {
+      msgId: response.data?.messages?.[0]?.msgId,
+      txId: response.data?.txId,
+    }
+
+    return result
+  }
+}
+
+export const chesService = new ChesService()

--- a/backend/src/services/config.service.ts
+++ b/backend/src/services/config.service.ts
@@ -9,12 +9,20 @@ export type LogLevel = 'error' | 'info' | 'debug'
 
 export interface AppConfig {
   allowedOrigins: string[]
+  appBaseUrl?: string
   bcgovSsoApi: {
     clientId: string
     clientSecret: string
     tokenUrl: string
     url: string
     urlBceid: string
+  }
+  ches: {
+    adminNotificationEmail?: string
+    apiUrl?: string
+    clientId?: string
+    clientSecret?: string
+    tokenUrl?: string
   }
   logLevel: LogLevel
   oidc: {
@@ -98,6 +106,14 @@ export function loadConfig() {
     allowedOrigins: process.env.ALLOWED_ORIGINS
       ? process.env.ALLOWED_ORIGINS.split(',')
       : ['*'],
+    appBaseUrl: process.env.APP_BASE_URL,
+    ches: {
+      adminNotificationEmail: process.env.ADMIN_NOTIFICATION_EMAIL,
+      apiUrl: process.env.CHES_API_URL,
+      clientId: process.env.CHES_CLIENT_ID,
+      clientSecret: process.env.CHES_CLIENT_SECRET,
+      tokenUrl: process.env.CHES_TOKEN_URL,
+    },
     bcgovSsoApi: {
       clientId: process.env.BCGOV_SSO_API_CLIENT_ID,
       clientSecret: process.env.BCGOV_SSO_API_CLIENT_SECRET,

--- a/backend/src/services/notification.service.ts
+++ b/backend/src/services/notification.service.ts
@@ -1,0 +1,96 @@
+import logger from '../common/logger'
+import { getErrorMessage } from '../common/error.handler'
+import { TenantRequest } from '../entities/TenantRequest'
+import { chesService } from './ches.service'
+import { config } from './config.service'
+
+const TENANT_REQUEST_CREATED = 'tenant_request_created'
+
+function formatRequestedAt(requestedAt: Date | string | undefined): string {
+  if (!requestedAt) {
+    return 'Not recorded'
+  }
+
+  const value =
+    requestedAt instanceof Date
+      ? requestedAt.toISOString()
+      : String(requestedAt)
+
+  return value.split('T')[0]
+}
+
+export class NotificationService {
+  public isEnabled(): boolean {
+    return Boolean(
+      chesService.isConfigured() && config.ches?.adminNotificationEmail,
+    )
+  }
+
+  private buildTenantRequestCreatedEmail(tenantRequest: TenantRequest) {
+    const requestsUrl = `${config.appBaseUrl || ''}/settings/requests`
+
+    const details = [
+      ['Name', tenantRequest.name || ''],
+      ['Ministry name', tenantRequest.ministryName || ''],
+      ['Description', tenantRequest.description || 'Not provided'],
+      ['Requested by', tenantRequest.requestedBy?.displayName || 'Unknown'],
+      ['Requested at', formatRequestedAt(tenantRequest.requestedAt)],
+    ]
+      .map(([label, value]) => `${label}: ${value}`)
+      .join('\n')
+
+    return {
+      subject: `New CSTAR tenant request: ${tenantRequest.name}`,
+      body: [
+        'A new tenant request has been submitted in CSTAR and is awaiting a decision.',
+        '',
+        details,
+        '',
+        'Review tenant requests in CSTAR:',
+        requestsUrl,
+      ].join('\n'),
+    }
+  }
+
+  public async notifyTenantRequestCreated(tenantRequest: TenantRequest) {
+    try {
+      const email = this.buildTenantRequestCreatedEmail(tenantRequest)
+
+      if (!this.isEnabled()) {
+        logger.info('Notification skipped - CHES is not configured', {
+          event: TENANT_REQUEST_CREATED,
+          tenantRequestId: tenantRequest.id,
+        })
+        logger.debug('Notification content', {
+          event: TENANT_REQUEST_CREATED,
+          subject: email.subject,
+          body: email.body,
+        })
+
+        return
+      }
+
+      const result = await chesService.sendEmail({
+        to: [config.ches.adminNotificationEmail as string],
+        subject: email.subject,
+        body: email.body,
+      })
+
+      logger.info('Notification sent', {
+        event: TENANT_REQUEST_CREATED,
+        tenantRequestId: tenantRequest.id,
+        msgId: result.msgId,
+        txId: result.txId,
+      })
+    } catch (error: unknown) {
+      logger.error('Notification failed', {
+        event: TENANT_REQUEST_CREATED,
+        tenantRequestId: tenantRequest?.id,
+        tenantName: tenantRequest?.name,
+        reason: getErrorMessage(error),
+      })
+    }
+  }
+}
+
+export const notificationService = new NotificationService()

--- a/backend/src/services/tenant-request.service.ts
+++ b/backend/src/services/tenant-request.service.ts
@@ -4,6 +4,7 @@ import { tenantRequestRepository } from '../repositories/tenant-request.reposito
 import { connection } from '../common/db.connection'
 import logger from '../common/logger'
 import { getErrorMessage } from '../common/error.handler'
+import { notificationService } from './notification.service'
 import {
   CreateTenantRequestInputDto,
   GetTenantRequestsInputDto,
@@ -85,6 +86,9 @@ export class TenantRequestService {
         throw error
       }
     })
+
+    await notificationService.notifyTenantRequestCreated(tenantRequest)
+
     return {
       data: {
         tenantRequest: {

--- a/backend/src/tests/services/ches.service.test.ts
+++ b/backend/src/tests/services/ches.service.test.ts
@@ -1,0 +1,102 @@
+import axios from 'axios'
+import { ChesService } from '../../services/ches.service'
+import { config } from '../../services/config.service'
+
+jest.mock('axios')
+
+const mockAxios = axios as jest.Mocked<typeof axios>
+
+describe('ChesService', () => {
+  let service: ChesService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new ChesService()
+    config.ches = {
+      adminNotificationEmail: 'cstar.admin@gov.bc.ca',
+      apiUrl: 'https://ches.example/api/v1/email',
+      clientId: 'client',
+      clientSecret: 'secret',
+      tokenUrl: 'https://token.example/token',
+    }
+  })
+
+  function mockTokenThenSend() {
+    mockAxios.post
+      .mockResolvedValueOnce({
+        data: { access_token: 'token-1', expires_in: 300 },
+      })
+      .mockResolvedValueOnce({
+        data: { messages: [{ msgId: 'msg-1' }], txId: 'tx-1' },
+      })
+  }
+
+  it('reports configured only when every CHES setting is present', () => {
+    expect(service.isConfigured()).toBe(true)
+
+    config.ches.clientSecret = undefined
+
+    expect(service.isConfigured()).toBe(false)
+  })
+
+  it('tells CHES the body is plain text', async () => {
+    mockTokenThenSend()
+
+    await service.sendEmail({ to: ['a@gov.bc.ca'], subject: 's', body: 'b' })
+
+    expect(mockAxios.post.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ bodyType: 'text' }),
+    )
+  })
+
+  it('returns the CHES message and transaction ids', async () => {
+    mockTokenThenSend()
+
+    const result = await service.sendEmail({
+      to: ['cstar.admin@gov.bc.ca'],
+      subject: 'New CSTAR tenant request: My Tenant',
+      body: '<p>hello</p>',
+    })
+
+    expect(result).toEqual({ msgId: 'msg-1', txId: 'tx-1' })
+  })
+
+  it('reuses a cached token instead of fetching one per email', async () => {
+    mockTokenThenSend()
+    mockAxios.post.mockResolvedValue({
+      data: { messages: [{ msgId: 'msg-2' }], txId: 'tx-2' },
+    })
+
+    await service.sendEmail({ to: ['a@gov.bc.ca'], subject: 's', body: 'b' })
+    await service.sendEmail({ to: ['a@gov.bc.ca'], subject: 's', body: 'b' })
+
+    const tokenCalls = mockAxios.post.mock.calls.filter(
+      (call) => call[0] === 'https://token.example/token',
+    )
+
+    expect(tokenCalls).toHaveLength(1)
+  })
+
+  it('sends the email with a bounded timeout so it cannot stall the request', async () => {
+    mockTokenThenSend()
+
+    await service.sendEmail({ to: ['a@gov.bc.ca'], subject: 's', body: 'b' })
+
+    const sendCall = mockAxios.post.mock.calls[1]
+
+    expect(sendCall[2]).toEqual(
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    )
+    expect((sendCall[2] as { timeout: number }).timeout).toBeLessThanOrEqual(
+      5000,
+    )
+  })
+
+  it('reports a clear error when the token cannot be obtained', async () => {
+    mockAxios.post.mockRejectedValueOnce(new Error('bad credentials'))
+
+    await expect(
+      service.sendEmail({ to: ['a@gov.bc.ca'], subject: 's', body: 'b' }),
+    ).rejects.toThrow('Failed to obtain CHES access token: bad credentials')
+  })
+})

--- a/backend/src/tests/services/notification.service.test.ts
+++ b/backend/src/tests/services/notification.service.test.ts
@@ -1,0 +1,173 @@
+import { NotificationService } from '../../services/notification.service'
+import { chesService } from '../../services/ches.service'
+import { config } from '../../services/config.service'
+import logger from '../../common/logger'
+import { TenantRequest } from '../../entities/TenantRequest'
+
+jest.mock('../../services/ches.service', () => ({
+  chesService: {
+    isConfigured: jest.fn(),
+    sendEmail: jest.fn(),
+  },
+}))
+
+jest.mock('../../common/logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const mockChes = chesService as jest.Mocked<typeof chesService>
+const mockLogger = logger as jest.Mocked<typeof logger>
+
+function buildTenantRequest(): TenantRequest {
+  return {
+    id: 'request-1',
+    name: 'My Tenant',
+    ministryName: 'BC Elections',
+    description: 'A new tenant for elections work',
+    requestedAt: '2026-07-30',
+    requestedBy: { displayName: 'Falk, Barrett CITZ:EX' },
+  } as unknown as TenantRequest
+}
+
+describe('notifyTenantRequestCreated', () => {
+  let service: NotificationService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new NotificationService()
+    config.ches = {
+      adminNotificationEmail: 'cstar.admin@gov.bc.ca',
+      apiUrl: 'https://ches.example/api/v1/email',
+      clientId: 'client',
+      clientSecret: 'secret',
+      tokenUrl: 'https://token.example/token',
+    }
+    config.appBaseUrl = 'https://cstar.example'
+    mockChes.isConfigured.mockReturnValue(true)
+    mockChes.sendEmail.mockResolvedValue({ msgId: 'msg-1', txId: 'tx-1' })
+  })
+
+  it('sends the email to the configured admin mailbox', async () => {
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    expect(mockChes.sendEmail).toHaveBeenCalledTimes(1)
+    expect(mockChes.sendEmail.mock.calls[0][0].to).toEqual([
+      'cstar.admin@gov.bc.ca',
+    ])
+  })
+
+  it('includes every detail the operations admin needs to decide', async () => {
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    const email = mockChes.sendEmail.mock.calls[0][0]
+
+    expect(email.subject).toBe('New CSTAR tenant request: My Tenant')
+    expect(email.body).toContain('My Tenant')
+    expect(email.body).toContain('BC Elections')
+    expect(email.body).toContain('A new tenant for elections work')
+    expect(email.body).toContain('Falk, Barrett CITZ:EX')
+    expect(email.body).toContain('2026-07-30')
+    expect(email.body).toContain('https://cstar.example/settings/requests')
+  })
+
+  it('logs the CHES message id so delivery can be traced', async () => {
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    expect(mockLogger.info).toHaveBeenCalledWith('Notification sent', {
+      event: 'tenant_request_created',
+      tenantRequestId: 'request-1',
+      msgId: 'msg-1',
+      txId: 'tx-1',
+    })
+  })
+
+  it('never logs the recipient address or the email body on success', async () => {
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    const logged = JSON.stringify(mockLogger.info.mock.calls)
+
+    expect(logged).not.toContain('cstar.admin@gov.bc.ca')
+    expect(logged).not.toContain('BC Elections')
+  })
+
+  it('does not throw when CHES fails, so the tenant request still succeeds', async () => {
+    mockChes.sendEmail.mockRejectedValue(new Error('CHES unavailable'))
+
+    await expect(
+      service.notifyTenantRequestCreated(buildTenantRequest()),
+    ).resolves.toBeUndefined()
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Notification failed', {
+      event: 'tenant_request_created',
+      tenantRequestId: 'request-1',
+      tenantName: 'My Tenant',
+      reason: 'CHES unavailable',
+    })
+  })
+
+  it('logs the email instead of sending it when CHES is not configured', async () => {
+    mockChes.isConfigured.mockReturnValue(false)
+
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    expect(mockChes.sendEmail).not.toHaveBeenCalled()
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Notification skipped - CHES is not configured',
+      { event: 'tenant_request_created', tenantRequestId: 'request-1' },
+    )
+    expect(mockLogger.debug).toHaveBeenCalled()
+  })
+
+  it('skips sending when no admin mailbox is configured', async () => {
+    config.ches.adminNotificationEmail = undefined
+
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    expect(mockChes.sendEmail).not.toHaveBeenCalled()
+  })
+
+  it('falls back gracefully when the request has no description', async () => {
+    const tenantRequest = buildTenantRequest()
+    tenantRequest.description = undefined as unknown as string
+
+    await service.notifyTenantRequestCreated(tenantRequest)
+
+    expect(mockChes.sendEmail.mock.calls[0][0].body).toContain('Not provided')
+  })
+
+  it('does not throw even when the tenant request is unusable', async () => {
+    await expect(
+      service.notifyTenantRequestCreated(null as unknown as TenantRequest),
+    ).resolves.toBeUndefined()
+
+    expect(mockLogger.error).toHaveBeenCalled()
+  })
+
+  it('builds a plain text body with no markup', async () => {
+    await service.notifyTenantRequestCreated(buildTenantRequest())
+
+    const body = mockChes.sendEmail.mock.calls[0][0].body
+
+    expect(body).not.toMatch(/<[a-z]/i)
+    expect(body).toContain('Name: My Tenant')
+    expect(body).toContain('Ministry name: BC Elections')
+    expect(body).toContain('Requested at: 2026-07-30')
+  })
+
+  it('leaves the tenant name unaltered, as plain text needs no escaping', async () => {
+    const tenantRequest = buildTenantRequest()
+    tenantRequest.name = 'Roads & Bridges'
+
+    await service.notifyTenantRequestCreated(tenantRequest)
+
+    expect(mockChes.sendEmail.mock.calls[0][0].body).toContain(
+      'Name: Roads & Bridges',
+    )
+  })
+})

--- a/backend/src/tests/services/tenant-request.service.test.ts
+++ b/backend/src/tests/services/tenant-request.service.test.ts
@@ -4,6 +4,7 @@ import { TenantRequestService } from '../../services/tenant-request.service'
 import { tenantRequestRepository } from '../../repositories/tenant-request.repository'
 import { connection } from '../../common/db.connection'
 import logger from '../../common/logger'
+import { notificationService } from '../../services/notification.service'
 
 jest.mock('../../repositories/tenant-request.repository')
 jest.mock('../../common/logger')
@@ -14,6 +15,11 @@ jest.mock('../../common/db.connection', () => ({
     },
   },
 }))
+jest.mock('../../services/notification.service', () => ({
+  notificationService: {
+    notifyTenantRequestCreated: jest.fn(),
+  },
+}))
 
 const FAKE_TX = { marker: 'fake-tx' } as unknown as EntityManager
 
@@ -22,6 +28,7 @@ const mockRepository = tenantRequestRepository as jest.Mocked<
 >
 const mockTransaction = connection.manager.transaction as jest.Mock
 const mockLoggerError = logger.error as jest.Mock
+const mockNotify = notificationService.notifyTenantRequestCreated as jest.Mock
 
 function asRequest(overrides: Partial<Request>): Request {
   return overrides as Request
@@ -118,6 +125,23 @@ describe('TenantRequestService', () => {
         'Create tenant request transaction failure - rolling back inserts ',
         { error: 'db down' },
       )
+    })
+
+    it('notifies the operations admin mailbox once the request is saved', async () => {
+      const saved = { id: 'tr-1', requestedBy: { displayName: 'John Smith' } }
+      mockRepository.saveTenantRequest.mockResolvedValue(saved as never)
+
+      await service.createTenantRequest(req)
+
+      expect(mockNotify).toHaveBeenCalledWith(saved)
+    })
+
+    it('does not notify when the request was not saved', async () => {
+      mockRepository.saveTenantRequest.mockRejectedValue(new Error('db down'))
+
+      await expect(service.createTenantRequest(req)).rejects.toThrow('db down')
+
+      expect(mockNotify).not.toHaveBeenCalled()
     })
   })
 

--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -97,6 +97,18 @@ spec:
               value: "{{ .Values.backend.tmsAudience }}"
             - name: LOG_LEVEL
               value: "{{ .Values.global.env.logLevel }}"
+            - name: CHES_TOKEN_URL
+              value: "{{ .Values.backend.chesTokenUrl }}"
+            - name: CHES_API_URL
+              value: "{{ .Values.backend.chesApiUrl }}"
+            - name: CHES_CLIENT_ID
+              value: "{{ .Values.backend.chesClientId }}"
+            - name: CHES_CLIENT_SECRET
+              value: "{{ .Values.backend.chesClientSecret }}"
+            - name: ADMIN_NOTIFICATION_EMAIL
+              value: "{{ .Values.backend.adminNotificationEmail }}"
+            - name: APP_BASE_URL
+              value: "{{ .Values.backend.appBaseUrl }}"
           ports:
             - name: http
               containerPort: {{ .Values.backend.service.targetPort }}


### PR DESCRIPTION
Description

Following are the changes in the PR:

1. CHES integration to send emails to specific mailbox when tenant requests are created
2. New layers -services for ches and notifications
3. Updates to config for new ches env vars 
4. Unit tests added for ches service, notification service 
5. Unit tests updated for tenant request service 
6. Deployment yaml updates to add new env vars to envs

Type of change

`build`: changes to the build system or dependencies
`feat`: a new feature for the product
`test`: adding missing tests or correcting existing tests

Checklist

- [x] I have performed a thorough self-review of the changes in this PR
- [x] The changes are self-explanatory or have comments where needed
- [x] I have checked that documentation is still accurate after these changes
- [x] My changes are covered by the existing tests or tests have been added

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://cstar-645.apps.gold.devops.gov.bc.ca)
- [Backend](https://cstar-645.apps.gold.devops.gov.bc.ca/api/v1)
- [OpenAPI](https://cstar-645.apps.gold.devops.gov.bc.ca/api/v1/docs)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tenant-management-system/actions/workflows/merge.yml)